### PR TITLE
feat: date audit table 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/CatvillageApplication.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/CatvillageApplication.java
@@ -2,7 +2,9 @@ package com.twentyfour_seven.catvillage;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class CatvillageApplication {
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
@@ -1,0 +1,24 @@
+package com.twentyfour_seven.catvillage.audit;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.util.Date;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class DateTable {
+    @CreatedDate
+    @Column(name = "CREATED_DATE", updatable = false)
+    private Date createdDate;
+
+    @LastModifiedDate
+    @Column(name = "MODIFIED_DATE", updatable = false)
+    private Date modifiedDate;
+}


### PR DESCRIPTION
## 주요 변경 사항
- 생성일, 수정일을 기록하는 date audit table 추가
- EnableJpaAuditing annotation 추가

## 코드 변경 이유
- 컬럼 중 데이터 생성일, 수정일을 공용으로 사용하기 위한 date audit table 추가
- audit을 정상적으로 사용하기 위해서 EnableJpaAuditing 어노테이션 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatvillageApplication class에 어노테이션 적용 부분
- DateTable class

## 연결된 이슈
resolved #31

## 자료 (스크린샷 등)
