### PR TITLE
feat: 특정 고양이 프로필 보기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -1,10 +1,23 @@
 package com.twentyfour_seven.catvillage.cat.controller;
 
+import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
+import com.twentyfour_seven.catvillage.cat.entity.CatTag;
+import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
+import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.constraints.Positive;
+import java.util.List;
 
 @RestController
 @RequestMapping("/cats")
@@ -12,8 +25,23 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class CatController {
     private final CatService catService;
+    private final CatMapper catMapper;
+    private final CatTagMapper catTagMapper;
 
-    public CatController(CatService catService){
+    public CatController(CatService catService, CatMapper catMapper,
+                         CatTagMapper catTagMapper){
         this.catService = catService;
+        this.catMapper = catMapper;
+        this.catTagMapper = catTagMapper;
+    }
+
+    @GetMapping("/{cats-id}")
+    public ResponseEntity getCat(@PathVariable("cats-id") @Positive long catId) {
+        Cat cat = catService.findCat(catId);
+        CatResponseDto catResponseDto = catMapper.catToCatResponseDto(cat);
+        List<CatTag> catTags =  catTagMapper.tagToCatsToCatTags(cat.getTagToCats());
+        List<CatTagResponseDto> catTagResponseDtos = catTagMapper.catTagsToCatTagResponseDtos(catTags);
+        catResponseDto.setTags(catTagResponseDtos);
+        return new ResponseEntity<>(catResponseDto, HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
@@ -34,5 +34,5 @@ public class CatPostDto {
     @Length(max = 1000)
     private String body;
 
-    private List<CatTagPostDto> tag;
+    private List<CatTagPostDto> tags;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
@@ -1,4 +1,24 @@
 package com.twentyfour_seven.catvillage.cat.dto;
 
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
 public class CatResponseDto {
+    long catId;
+    String name;
+    int birthYear;
+    int birthMonth;
+    int birthDay;
+    String breed;
+    String sex;
+    int weight;
+    String image;
+    String body;
+    List<CatTagResponseDto> tags;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagPostDto.java
@@ -2,9 +2,13 @@ package com.twentyfour_seven.catvillage.cat.dto;
 
 import lombok.Getter;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
 @Getter
 @Setter
+@Validated
 public class CatTagPostDto {
+    @Length(max = 15)
     private String tag;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagResponseDto.java
@@ -1,0 +1,12 @@
+package com.twentyfour_seven.catvillage.cat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class CatTagResponseDto {
+    private String tag;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
@@ -2,6 +2,7 @@ package com.twentyfour_seven.catvillage.cat.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.twentyfour_seven.catvillage.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
@@ -1,12 +1,13 @@
 package com.twentyfour_seven.catvillage.cat.mapper;
 
 import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
 import java.time.LocalDateTime;
-import java.util.Date;
+import java.util.ArrayList;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CatMapper {
@@ -23,5 +24,26 @@ public interface CatMapper {
                 .body(catPostDto.getBody())
                 .build();
         return cat;
+    }
+
+    default public CatResponseDto catToCatResponseDto(Cat cat) {
+        if (cat == null) {
+            return null;
+        }
+        LocalDateTime birthDate = cat.getBirthDate();
+        CatResponseDto catResponseDto = new CatResponseDto(
+                cat.getCatId(),
+                cat.getName(),
+                birthDate.getYear(),
+                birthDate.getMonthValue(),
+                birthDate.getDayOfMonth(),
+                cat.getBreed().getKorName(),
+                cat.getSex(),
+                cat.getWeight(),
+                cat.getImage(),
+                cat.getBody(),
+                new ArrayList<>()
+        );
+        return catResponseDto;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
@@ -2,7 +2,9 @@ package com.twentyfour_seven.catvillage.cat.mapper;
 
 import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagPostDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.CatTag;
+import com.twentyfour_seven.catvillage.cat.entity.TagToCat;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
@@ -16,4 +18,17 @@ public interface CatTagMapper {
         return catTag;
     }
     public List<CatTag> catTagPostDtosToCatTags(List<CatPostDto> catPostDtos);
+
+    default public CatTagResponseDto catTagToCatTagResponseDto(CatTag catTag) {
+        CatTagResponseDto catTagResponseDto = new CatTagResponseDto(catTag.getTagName());
+        return catTagResponseDto;
+    }
+
+    public List<CatTagResponseDto> catTagsToCatTagResponseDtos(List<CatTag> catTags);
+
+    default public CatTag tagToCatToCatTag(TagToCat tagToCat) {
+        return tagToCat.getCatTag();
+    }
+
+    public List<CatTag> tagToCatsToCatTags(List<TagToCat> tagToCats);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -4,6 +4,10 @@ import com.twentyfour_seven.catvillage.cat.entity.Breed;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.cat.repository.BreedRepository;
 import com.twentyfour_seven.catvillage.cat.repository.CatRepository;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.service.UserService;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -33,5 +37,15 @@ public class CatService {
         Optional<Breed> optionalBreed = breedRepository.findByKorName(breed);
         Breed findBreed = optionalBreed.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
         return findBreed;
+    }
+
+    public Cat findCat(long catId) {
+        return findVerifiedCat(catId);
+    }
+
+    public Cat findVerifiedCat(long catId) {
+        Optional<Cat> optionalCat = catRepository.findById(catId);
+        Cat findCat = optionalCat.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CAT_NOT_FOUND));
+        return findCat;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -4,7 +4,9 @@ import lombok.Getter;
 
 public enum ExceptionCode {
     MEMBER_NOT_FOUND(404, "Member not found"),
-    MEMBER_EXISTS(409, "Member exists");
+    MEMBER_EXISTS(409, "Member exists"),
+    BREED_NOT_FOUND(404, "Breed not found"),
+    CAT_NOT_FOUND(409, "Cat not found");
 
     @Getter
     private final int status;


### PR DESCRIPTION
## 주요 변경 사항
- ExceptionCode에 Breed not found와 Cat not found 에러 코드를 추가
- CatTagPostDto에 tag 길이 15로 지정하는 애너테이션 추가
- 고양이 프로필 정보 불러오는 요청시 응답에 필요한 CatResponseDto 구현
- CatController에 특정 고양이 프로필 요청에 응답하는 메서드 추가
- cat과 tag를 각각 mapper에서 dto로 변환해주도록 구현

## 코드 변경 이유
- tag의 길이를 DB에서 15로 설계했기 때문에 catTag 입력받을 시 길이를 검증하도록 추가했습니다.
- 특정 고양이 프로필 정보 보기 기능에 필요한 클래스 및 메서드를 추가했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatController
- CatService
- CatMapper
- CatTagMapper

## 연결된 이슈
close #10 

## 자료 (스크린샷 등)
