### PR TITLE
fix: date table 변수 타입 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -16,9 +16,9 @@ import java.util.Date;
 public abstract class DateTable {
     @CreatedDate
     @Column(name = "CREATED_DATE", updatable = false)
-    private Date createdDate;
+    private LocalDateTime createdDate;
 
     @LastModifiedDate
     @Column(name = "MODIFIED_DATE", updatable = false)
-    private Date modifiedDate;
+    private LocalDateTime modifiedDate;
 }


### PR DESCRIPTION
## 주요 변경 사항
- Date -> LocalDateTime 타입 변경
- Date 타입의 경우 레거시 타입이므로 사용을 지양하기 위해 변경

## 코드 변경 이유
- 레거시 타입인 Date 타입을 사용했었기에 LocalDateTime으로 변경
- Date 타입의 경우 JPA 사용시 문제를 야기할 수 있다는 내용을 봤었기에 지양하고자 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- DateTable class의 필드 변수 타입 변경 내용

## 연결된 이슈
fixed #44

## 자료 (스크린샷 등)
