### PR TITLE
style: 공통 레이아웃 설정

### DIFF
--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -11,6 +11,14 @@ export const GlobalStyle = createGlobalStyle`
   html, body {
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI Adjusted","Segoe UI","Liberation Sans",sans-serif;
   }
+
+  body {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
   
   input, textarea { 
     -moz-user-select: auto;

--- a/client/src/styles/Iphone11ProContainer.tsx
+++ b/client/src/styles/Iphone11ProContainer.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export const Iphone11ProContainer = styled.div`
+  border: 3px solid black;
+  width: 375px;
+  height: 812px;
+`


### PR DESCRIPTION
## 주요 변경 사항
- Iphone 11 Pro 사이즈(375 x 812)에 맞추어 공통 레이아웃을 설정했습니다.

## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분
- Iphone11ProContainer라는 컨테이너를 생성했습니다. (아래 스크린샷 참고)
- GlobalStyle의 body 요소에 display 속성을 이용해 컨테이너를 가운데 정렬했습니다.

## 연결된 이슈

## 자료 (스크린샷 등)
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/88873956/191172560-9c0b27d2-5cfd-4db6-89c0-b0528459657f.png">

