### PR TITLE
feat: 고양이 수정하기 및 삭제하기 기능 구현

### DIFF
--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -11,6 +11,14 @@ export const GlobalStyle = createGlobalStyle`
   html, body {
     font-family: -apple-system,BlinkMacSystemFont,"Segoe UI Adjusted","Segoe UI","Liberation Sans",sans-serif;
   }
+
+  body {
+    width: 100vw;
+    height: 100vh;
+    display: flex;
+    justify-content: center;
+    align-items: center;
+  }
   
   input, textarea { 
     -moz-user-select: auto;

--- a/client/src/styles/Iphone11ProContainer.tsx
+++ b/client/src/styles/Iphone11ProContainer.tsx
@@ -1,0 +1,7 @@
+import styled from 'styled-components'
+
+export const Iphone11ProContainer = styled.div`
+  border: 3px solid black;
+  width: 375px;
+  height: 812px;
+`

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/audit/DateTable.java
@@ -8,7 +8,7 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;
-import java.util.Date;
+import java.time.LocalDateTime;
 
 @Getter
 @MappedSuperclass
@@ -16,9 +16,9 @@ import java.util.Date;
 public abstract class DateTable {
     @CreatedDate
     @Column(name = "CREATED_DATE", updatable = false)
-    private Date createdDate;
+    private LocalDateTime createdDate;
 
     @LastModifiedDate
     @Column(name = "MODIFIED_DATE", updatable = false)
-    private Date modifiedDate;
+    private LocalDateTime modifiedDate;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.controller;
 
+import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
@@ -7,15 +8,14 @@ import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import com.twentyfour_seven.catvillage.cat.service.CatTagService;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
 
@@ -43,5 +43,16 @@ public class CatController {
         List<CatTagResponseDto> catTagResponseDtos = catTagMapper.catTagsToCatTagResponseDtos(catTags);
         catResponseDto.setTags(catTagResponseDtos);
         return new ResponseEntity<>(catResponseDto, HttpStatus.OK);
+    }
+
+    @PatchMapping("/{cats-id}")
+    public ResponseEntity patchCat(@PathVariable("cats-id") @Positive long catId,
+                                   @Valid @RequestBody CatPostDto catPostDto) {
+        Cat cat = catMapper.catPostDtoToCat(catPostDto);
+        String breed = catPostDto.getBreed();
+        List<CatTag> catTags = catTagMapper.catTagPostDtosToCatTags(catPostDto.getTags());
+        // 토큰에서 User 정보 불러와서 Cat에 저장 필요!
+        Cat saveCat = catService.saveCat(cat, breed, catTags);
+        return new ResponseEntity<>(catMapper.catToCatResponseDto(saveCat), HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -55,4 +55,11 @@ public class CatController {
         Cat saveCat = catService.saveCat(cat, breed, catTags);
         return new ResponseEntity<>(catMapper.catToCatResponseDto(saveCat), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{cats-id}")
+    public ResponseEntity deleteCat(@PathVariable("cats-id") @Positive long catId) {
+        catService.removeCat(catId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -52,7 +52,7 @@ public class CatController {
         String breed = catPostDto.getBreed();
         List<CatTag> catTags = catTagMapper.catTagPostDtosToCatTags(catPostDto.getTags());
         // 토큰에서 User 정보 불러와서 Cat에 저장 필요!
-        Cat saveCat = catService.saveCat(cat, breed, catTags);
+        Cat saveCat = catService.updateCat(cat, breed, catTags);
         return new ResponseEntity<>(catMapper.catToCatResponseDto(saveCat), HttpStatus.OK);
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCat.java
@@ -1,6 +1,7 @@
 package com.twentyfour_seven.catvillage.cat.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -11,6 +12,7 @@ import javax.persistence.ManyToOne;
 @Getter
 @Entity(name = "TAG_TO_CAT")
 @NoArgsConstructor
+@AllArgsConstructor
 public class TagToCat {
     @ManyToOne
     @JoinColumn(name = "TAG_ID")

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
@@ -17,7 +17,7 @@ public interface CatTagMapper {
         CatTag catTag = new CatTag(catTagPostDto.getTag());
         return catTag;
     }
-    public List<CatTag> catTagPostDtosToCatTags(List<CatPostDto> catPostDtos);
+    public List<CatTag> catTagPostDtosToCatTags(List<CatTagPostDto> catTagPostDtos);
 
     default public CatTagResponseDto catTagToCatTagResponseDto(CatTag catTag) {
         CatTagResponseDto catTagResponseDto = new CatTagResponseDto(catTag.getTagName());

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/CatTagRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/CatTagRepository.java
@@ -1,0 +1,10 @@
+package com.twentyfour_seven.catvillage.cat.repository;
+
+import com.twentyfour_seven.catvillage.cat.entity.CatTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface CatTagRepository extends JpaRepository<CatTag, Long> {
+    public Optional<CatTag> findByTagName(String tagName);
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/TagToCatRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/TagToCatRepository.java
@@ -1,0 +1,7 @@
+package com.twentyfour_seven.catvillage.cat.repository;
+
+import com.twentyfour_seven.catvillage.cat.entity.TagToCat;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagToCatRepository extends JpaRepository<TagToCat, Long> {
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
@@ -1,0 +1,25 @@
+package com.twentyfour_seven.catvillage.cat.service;
+
+import com.twentyfour_seven.catvillage.cat.entity.Breed;
+import com.twentyfour_seven.catvillage.cat.repository.BreedRepository;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class BreedService {
+    private final BreedRepository breedRepository;
+
+    public BreedService(BreedRepository breedRepository) {
+        this.breedRepository = breedRepository;
+    }
+
+    public Breed findVerifiedBreed(String breed) {
+        Optional<Breed> optionalBreed = breedRepository.findByKorName(breed);
+        Breed findBreed = optionalBreed.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
+        return findBreed;
+    }
+
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -49,4 +49,10 @@ public class CatService {
         Cat findCat = optionalCat.orElseThrow(() -> new BusinessLogicException(ExceptionCode.CAT_NOT_FOUND));
         return findCat;
     }
+
+    public void removeCat(long catId) {
+        Cat findCat = findVerifiedCat(catId);
+        catTagService.removeTagToCats(findCat.getTagToCats());
+        catRepository.delete(findCat);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -52,7 +52,7 @@ public class CatService {
 
     public void removeCat(long catId) {
         Cat findCat = findVerifiedCat(catId);
-        catTagService.removeTagToCats(findCat.getTagToCats());
+//        catTagService.removeTagToCats(findCat.getTagToCats());
         catRepository.delete(findCat);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -8,6 +8,7 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -20,13 +21,16 @@ public class CatService {
     private final BreedService breedService;
     private final UserService userService;
     private final CatTagService catTagService;
+    private final CustomBeanUtils<Cat> beanUtils;
 
     public CatService(CatRepository catRepository, BreedService breedService,
-                      UserService userService, CatTagService catTagService) {
+                      UserService userService, CatTagService catTagService,
+                      CustomBeanUtils beanUtils) {
         this.catRepository = catRepository;
         this.breedService = breedService;
         this.userService = userService;
         this.catTagService = catTagService;
+        this.beanUtils = beanUtils;
     }
 
     public Cat saveCat(Cat cat, String breed, List<CatTag> catTags) {
@@ -54,5 +58,14 @@ public class CatService {
         Cat findCat = findVerifiedCat(catId);
 //        catTagService.removeTagToCats(findCat.getTagToCats());
         catRepository.delete(findCat);
+    }
+
+    public Cat updateCat(Cat cat, String breed, List<CatTag> catTags) {
+        Cat findCat = findVerifiedCat(cat.getCatId());
+        Breed findBreed = breedService.findVerifiedBreed(breed);
+        cat.setBreed(findBreed);
+
+        Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
+        return catRepository.save(updatingCat);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -2,7 +2,7 @@ package com.twentyfour_seven.catvillage.cat.service;
 
 import com.twentyfour_seven.catvillage.cat.entity.Breed;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
-import com.twentyfour_seven.catvillage.cat.repository.BreedRepository;
+import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.repository.CatRepository;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
@@ -10,34 +10,35 @@ import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
 public class CatService {
     private final CatRepository catRepository;
-    private final BreedRepository breedRepository;
-    private final UserService userService;
 
-    public CatService(CatRepository catRepository, BreedRepository breedRepository, UserService userService) {
+    private final BreedService breedService;
+    private final UserService userService;
+    private final CatTagService catTagService;
+
+    public CatService(CatRepository catRepository, BreedService breedService,
+                      UserService userService, CatTagService catTagService) {
         this.catRepository = catRepository;
-        this.breedRepository = breedRepository;
+        this.breedService = breedService;
         this.userService = userService;
+        this.catTagService = catTagService;
     }
 
-    public Cat saveCat(Cat cat, String breed) {
+    public Cat saveCat(Cat cat, String breed, List<CatTag> catTags) {
         User user = userService.findVerifiedUser(userId);
         cat.setUser(user);
-        Breed findBreed = findVerifiedBreed(breed);
+        Breed findBreed = breedService.findVerifiedBreed(breed);
         cat.setBreed(findBreed);
+        catTagService.saveTag(catTags, cat);
         Cat createdCat = catRepository.save(cat);
         return createdCat;
     }
 
-    public Breed findVerifiedBreed(String breed) {
-        Optional<Breed> optionalBreed = breedRepository.findByKorName(breed);
-        Breed findBreed = optionalBreed.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
-        return findBreed;
-    }
 
     public Cat findCat(long catId) {
         return findVerifiedCat(catId);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
@@ -39,4 +39,8 @@ public class CatTagService {
         TagToCat createdTagToCat = tagToCatRepository.save(tagToCat);
         return createdTagToCat;
     }
+
+    public void removeTagToCats(List<TagToCat> tagToCats) {
+        tagToCatRepository.deleteAll(tagToCats);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
@@ -1,0 +1,42 @@
+package com.twentyfour_seven.catvillage.cat.service;
+
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
+import com.twentyfour_seven.catvillage.cat.entity.CatTag;
+import com.twentyfour_seven.catvillage.cat.entity.TagToCat;
+import com.twentyfour_seven.catvillage.cat.repository.CatTagRepository;
+import com.twentyfour_seven.catvillage.cat.repository.TagToCatRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class CatTagService {
+    private final CatTagRepository catTagRepository;
+    private final TagToCatRepository tagToCatRepository;
+
+    public CatTagService(CatTagRepository catTagRepository, TagToCatRepository tagToCatRepository) {
+        this.catTagRepository = catTagRepository;
+        this.tagToCatRepository = tagToCatRepository;
+    }
+
+    public List<CatTag> saveTag(List<CatTag> catTags, Cat cat) {
+        catTags.forEach(catTag -> {
+            catTag = findExistCatTag(catTag);
+            TagToCat tagToCat = new TagToCat(catTag, cat);
+            saveTagToCat(tagToCat);
+        });
+        return catTags;
+    }
+
+    public CatTag findExistCatTag (CatTag catTag) {
+        Optional<CatTag> optionalCatTag = catTagRepository.findByTagName(catTag.getTagName());
+        CatTag findCatTag = optionalCatTag.orElse(catTagRepository.save(catTag));
+        return findCatTag;
+    }
+
+    public TagToCat saveTagToCat(TagToCat tagToCat) {
+        TagToCat createdTagToCat = tagToCatRepository.save(tagToCat);
+        return createdTagToCat;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/dto/MultiResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/dto/MultiResponseDto.java
@@ -1,0 +1,23 @@
+package com.twentyfour_seven.catvillage.dto;
+
+import lombok.Getter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+public class MultiResponseDto<T> {
+    private List<T> items;
+    private int page;
+    private int pageSize;
+    private int totalPages;
+    private long totalElements;
+
+    public MultiResponseDto(List<T> items, Page pageInfo) {
+        this.items = items;
+        this.page = pageInfo.getNumber() + 1;
+        this.pageSize = pageInfo.getSize();
+        this.totalPages = pageInfo.getTotalPages();
+        this.totalElements = pageInfo.getTotalElements();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -25,7 +25,7 @@ public class User {
     private String password;
 
     @Setter
-    @Column(name = "NAME", nullable = false, length = 16)
+    @Column(name = "NAME", nullable = false, unique = true, length = 16)
     private String name;
 
     @Setter


### PR DESCRIPTION
## 주요 변경 사항
- CatTag, TagToCat repository 구현
- CatTagService에서 tag를 입력받아 저장하는 로직 구현
- 로그인 정보를 토큰에서 가져오는 로직 미구현해서 나중에 추가 필요
- 고양이 breed(품종) 관련된 로직은 확장성을 위해 BreedService로 분리
- CatController에 deleteCat 및 CatService에 removeCat 로직 구현
- removeCat 호출 시 Cat에 연결된 TagToCat리스트는 Cat 삭제 시 같이 삭제되도록 구현

## 코드 변경 이유
- 고양이 등록하기 및 수정하기에서 입력한 tag를 저장하기 위해 tag service와 repository를 분리하였습니다.
- 고양이 수정하기, 삭제하기 요청 시 CatService에서 CatTagService를 호출하여 tag 관련된 로직을 처리합니다.
- CatTag db에 저장 시 TagToCat도 저장이 필요하기 때문에 그부분도 로직에 추가하였습니다.
- 차후에 관리자가 품종을 등록, 삭제, 수정하는 로직 구현을 위해 breed service를 분리하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatService에서 saveCat의 매개변수
- TagService에서 CatTag와 TagToCat 저장 로직이 올바른지 확인

## 연결된 이슈
- close #12 
- close #13 

## 자료 (스크린샷 등)
