### PR TITLE
fix: user의 name 컬럼에 unique 적용

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -25,7 +25,7 @@ public class User {
     private String password;
 
     @Setter
-    @Column(name = "NAME", nullable = false, length = 16)
+    @Column(name = "NAME", nullable = false, unique = true, length = 16)
     private String name;
 
     @Setter


### PR DESCRIPTION
## 주요 변경 사항
- user의 name 컬럼은 중복이 있으면 안되기 때문에 unique 설정 적용

## 코드 변경 이유
- 데이터 중복이 발생하면 안되는 컬럼에 unique 설정이 빠져있었기에 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- user entity에 name 컬럼 unique 설정 추가 부분

## 연결된 이슈
fixed #49

## 자료 (스크린샷 등)
