### PR TITLE
feat: 고양이 품종 전체보기, 추가하기, 삭제하기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -82,4 +82,10 @@ public class CatController {
         return new ResponseEntity<>(
                 breedMapper.breedToBreedResponseDto(saveBreed), HttpStatus.CREATED);
     }
+
+    @DeleteMapping("/breeds/{breeds-id}")
+    public ResponseEntity deleteBreed(@PathVariable("breeds-id") @Positive long breedId) {
+        catService.removeBreed(breedId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.controller;
 
+import com.twentyfour_seven.catvillage.cat.dto.BreedPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
@@ -72,5 +73,13 @@ public class CatController {
         List<Breed> breeds = catService.findBreeds();
         return new ResponseEntity<>(
                 breedMapper.breedsToBreedResponseDtos(breeds), HttpStatus.OK);
+    }
+
+    @PostMapping("/breeds")
+    public ResponseEntity postBreed(@Valid @RequestBody BreedPostDto breedPostDto) {
+        Breed breed = breedMapper.breedPostDtoToBreed(breedPostDto);
+        Breed saveBreed = catService.saveBreed(breed);
+        return new ResponseEntity<>(
+                breedMapper.breedToBreedResponseDto(saveBreed), HttpStatus.CREATED);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -3,8 +3,10 @@ package com.twentyfour_seven.catvillage.cat.controller;
 import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
+import com.twentyfour_seven.catvillage.cat.entity.Breed;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.cat.entity.CatTag;
+import com.twentyfour_seven.catvillage.cat.mapper.BreedMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
@@ -27,12 +29,15 @@ public class CatController {
     private final CatService catService;
     private final CatMapper catMapper;
     private final CatTagMapper catTagMapper;
+    private final BreedMapper breedMapper;
 
     public CatController(CatService catService, CatMapper catMapper,
-                         CatTagMapper catTagMapper){
+                         CatTagMapper catTagMapper,
+                         BreedMapper breedMapper){
         this.catService = catService;
         this.catMapper = catMapper;
         this.catTagMapper = catTagMapper;
+        this.breedMapper = breedMapper;
     }
 
     @GetMapping("/{cats-id}")
@@ -62,4 +67,10 @@ public class CatController {
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
+    @GetMapping("/breeds")
+    public ResponseEntity getBreeds() {
+        List<Breed> breeds = catService.findBreeds();
+        return new ResponseEntity<>(
+                breedMapper.breedsToBreedResponseDtos(breeds), HttpStatus.OK);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/BreedPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/BreedPostDto.java
@@ -1,0 +1,16 @@
+package com.twentyfour_seven.catvillage.cat.dto;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@Validated
+public class BreedPostDto {
+    @Length(max = 20)
+    private String korName;
+    @Length(max = 20)
+    private String engName;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/BreedResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/BreedResponseDto.java
@@ -1,0 +1,14 @@
+package com.twentyfour_seven.catvillage.cat.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+public class BreedResponseDto {
+    private long breedId;
+    private String korName;
+    private String engName;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Breed.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Breed.java
@@ -17,10 +17,10 @@ public class Breed {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long breedId;
 
-    @Column(name = "KOR_NAME", nullable = false)
+    @Column(name = "KOR_NAME", length = 20, nullable = false)
     private String korName;
 
-    @Column(name = "ENG_NAME")
+    @Column(name = "ENG_NAME", length = 20)
     private String engName;
 
     @OneToMany(mappedBy = "breed")

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/BreedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/BreedMapper.java
@@ -1,0 +1,21 @@
+package com.twentyfour_seven.catvillage.cat.mapper;
+
+import com.twentyfour_seven.catvillage.cat.dto.BreedResponseDto;
+import com.twentyfour_seven.catvillage.cat.entity.Breed;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface BreedMapper {
+    default public BreedResponseDto breedToBreedResponseDto(Breed breed) {
+        if (breed == null) {
+            return null;
+        }
+        BreedResponseDto breedResponseDto = new BreedResponseDto(breed.getBreedId(),
+                breed.getKorName(), breed.getEngName());
+        return breedResponseDto;
+    }
+   public List<BreedResponseDto> breedsToBreedResponseDtos(List<Breed> breeds);
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/BreedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/BreedMapper.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.mapper;
 
+import com.twentyfour_seven.catvillage.cat.dto.BreedPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.BreedResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.Breed;
 import org.mapstruct.Mapper;
@@ -18,4 +19,6 @@ public interface BreedMapper {
         return breedResponseDto;
     }
    public List<BreedResponseDto> breedsToBreedResponseDtos(List<Breed> breeds);
+
+    Breed breedPostDtoToBreed(BreedPostDto breedPostDto);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
@@ -26,4 +26,8 @@ public class BreedService {
     public List<Breed> findAll() {
         return breedRepository.findAll();
     }
+
+    public Breed saveBreed(Breed breed) {
+        return breedRepository.save(breed);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
@@ -17,7 +17,7 @@ public class BreedService {
         this.breedRepository = breedRepository;
     }
 
-    public Breed findVerifiedBreed(String breed) {
+    public Breed findByBreedName(String breed) {
         Optional<Breed> optionalBreed = breedRepository.findByKorName(breed);
         Breed findBreed = optionalBreed.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
         return findBreed;
@@ -29,5 +29,16 @@ public class BreedService {
 
     public Breed saveBreed(Breed breed) {
         return breedRepository.save(breed);
+    }
+
+    public Breed findVerifiedBreed(long breedId) {
+        Optional<Breed> optionalBreed = breedRepository.findById(breedId);
+        Breed findBreed = optionalBreed.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
+        return findBreed;
+    }
+
+    public void removeBreed(long breedId) {
+        Breed breed = findVerifiedBreed(breedId);
+        breedRepository.delete(breed);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/BreedService.java
@@ -6,6 +6,7 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -22,4 +23,7 @@ public class BreedService {
         return findBreed;
     }
 
+    public List<Breed> findAll() {
+        return breedRepository.findAll();
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -73,4 +73,9 @@ public class CatService {
         List<Breed> findBreeds = breedService.findAll();
         return findBreeds;
     }
+
+    public Breed saveBreed(Breed breed) {
+        Breed createdBreed = breedService.saveBreed(breed);
+        return createdBreed;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -36,7 +36,7 @@ public class CatService {
     public Cat saveCat(Cat cat, String breed, List<CatTag> catTags) {
         User user = userService.findVerifiedUser(userId);
         cat.setUser(user);
-        Breed findBreed = breedService.findVerifiedBreed(breed);
+        Breed findBreed = breedService.findByBreedName(breed);
         cat.setBreed(findBreed);
         catTagService.saveTag(catTags, cat);
         Cat createdCat = catRepository.save(cat);
@@ -62,7 +62,7 @@ public class CatService {
 
     public Cat updateCat(Cat cat, String breed, List<CatTag> catTags) {
         Cat findCat = findVerifiedCat(cat.getCatId());
-        Breed findBreed = breedService.findVerifiedBreed(breed);
+        Breed findBreed = breedService.findByBreedName(breed);
         cat.setBreed(findBreed);
 
         Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
@@ -77,5 +77,9 @@ public class CatService {
     public Breed saveBreed(Breed breed) {
         Breed createdBreed = breedService.saveBreed(breed);
         return createdBreed;
+    }
+
+    public void removeBreed(long breedId) {
+        breedService.removeBreed(breedId);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -68,4 +68,9 @@ public class CatService {
         Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
         return catRepository.save(updatingCat);
     }
+
+    public List<Breed> findBreeds() {
+        List<Breed> findBreeds = breedService.findAll();
+        return findBreeds;
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
- CatController에 고양이 품종 관련 요청 받는 메서드 구현
- controller에서 다른 엔티티의 service를 호출하는 것은 적절치 않아 CatService 호출하고 catService가 breedService를 호출하도록 구현
- 품종 한글이름(korName), 영문이름(engName)을 DB설계에 맞춰 길이제한 20

## 코드 변경 이유
- 고양이 품종 정보 전체보기 요청 시 필요한 클래스를 구현했습니다.
- 고양이 품종 추가하기, 삭제하기 기능은 필수 기능이 아니므로 중점적으로 보지 않아도 됩니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- '고양이 품종 전체보기'는 필수 기능이므로 이부분만 중점적으로 보시면 됩니다.

## 연결된 이슈
- resolve #14 
- resolve #17 
- resolve #18 

## 자료 (스크린샷 등)
