### PR TITLE
feat: APP_API를 환경 변수에 추가 

### DIFF
--- a/client/env/.env.dev
+++ b/client/env/.env.dev
@@ -1,0 +1,2 @@
+PUBLIC_URL=http://localhost:3000
+APP_API=

--- a/client/env/.env.prod
+++ b/client/env/.env.prod
@@ -1,0 +1,2 @@
+PUBLIC_URL=
+APP_API=

--- a/client/webpack/webpack.common.js
+++ b/client/webpack/webpack.common.js
@@ -102,6 +102,7 @@ module.exports = (_env) => {
       }),
       new webpack.DefinePlugin({
         "process.env.PUBLIC_URL": JSON.stringify(process.env.PUBLIC_URL),
+        "process.env.APP_API": JSON.stringify(process.env.APP_API),
         "process.env.IMAGE_INLINE_SIZE_LIMIT": JSON.stringify(
           process.env.IMAGE_INLINE_SIZE_LIMIT
         ),


### PR DESCRIPTION
## 주요 변경 사항
webpack.DefinePlugin의 인자에로 APP_API를 추가해 주었습니다

## 코드 변경 이유
APP_API를 .env 파일에 명시하면 브라우저 환경에서 해당 환경변수를 사용할 수 있도록 기능을 추가하였습니다.
추가로, env template를 env폴더에 추가하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
```js
      new webpack.DefinePlugin({
        "process.env.PUBLIC_URL": JSON.stringify(process.env.PUBLIC_URL),
        // 아래 줄을 추가함으로써 브라우저 환경에서 APP_API를 process.env.APP_API로 접근 가능 
        "process.env.APP_API": JSON.stringify(process.env.APP_API),
        "process.env.IMAGE_INLINE_SIZE_LIMIT": JSON.stringify(
          process.env.IMAGE_INLINE_SIZE_LIMIT
        ),
      }),
```
## 연결된 이슈

## 자료 (스크린샷 등)
