### PR TITLE
fix: path alias 이름 수정

### DIFF
--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -51,6 +51,7 @@
         "prettier": "^2.7.1",
         "style-loader": "^3.3.1",
         "ts-loader": "^9.3.1",
+        "tsconfig-paths-webpack-plugin": "^4.0.0",
         "typescript": "^4.8.3",
         "url-loader": "^4.1.1",
         "webpack": "^5.74.0",
@@ -9812,6 +9813,34 @@
         "strip-bom": "^3.0.0"
       }
     },
+    "node_modules/tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/tsconfig-paths-webpack-plugin/node_modules/tsconfig-paths": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+      "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+      "dev": true,
+      "dependencies": {
+        "json5": "^2.2.1",
+        "minimist": "^1.2.6",
+        "strip-bom": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/tsconfig-paths/node_modules/json5": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
@@ -17584,6 +17613,30 @@
           "dev": true,
           "requires": {
             "minimist": "^1.2.0"
+          }
+        }
+      }
+    },
+    "tsconfig-paths-webpack-plugin": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths-webpack-plugin/-/tsconfig-paths-webpack-plugin-4.0.0.tgz",
+      "integrity": "sha512-fw/7265mIWukrSHd0i+wSwx64kYUSAKPfxRDksjKIYTxSAp9W9/xcZVBF4Kl0eqQd5eBpAQ/oQrc5RyM/0c1GQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^4.1.0",
+        "enhanced-resolve": "^5.7.0",
+        "tsconfig-paths": "^4.0.0"
+      },
+      "dependencies": {
+        "tsconfig-paths": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-4.1.0.tgz",
+          "integrity": "sha512-AHx4Euop/dXFC+Vx589alFba8QItjF+8hf8LtmuiCwHyI4rHXQtOOENaM8kvYf5fR0dRChy3wzWIZ9WbB7FWow==",
+          "dev": true,
+          "requires": {
+            "json5": "^2.2.1",
+            "minimist": "^1.2.6",
+            "strip-bom": "^3.0.0"
           }
         }
       }

--- a/client/package.json
+++ b/client/package.json
@@ -57,6 +57,7 @@
     "prettier": "^2.7.1",
     "style-loader": "^3.3.1",
     "ts-loader": "^9.3.1",
+    "tsconfig-paths-webpack-plugin": "^4.0.0",
     "typescript": "^4.8.3",
     "url-loader": "^4.1.1",
     "webpack": "^5.74.0",

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -1,11 +1,7 @@
 {
   "compilerOptions": {
     "target": "es5",
-    "lib": [
-      "dom",
-      "dom.iterable",
-      "esnext"
-    ],
+    "lib": ["dom", "dom.iterable", "esnext"],
     "allowJs": true,
     "skipLibCheck": true,
     "esModuleInterop": true,
@@ -17,13 +13,24 @@
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "isolatedModules": true,
-    "jsx": "react-jsx"
+    "jsx": "react-jsx",
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["./src/*"],
+      "@Types/*": ["./src/@types/*"],
+      "@Api/*": ["./src/api/*"],
+      "@Assets/*": ["./src/assets/*"],
+      "@Components/*": ["./src/components/*"],
+      "@Hooks/*": ["./src/hooks/*"],
+      "@Layout/*": ["./src/layout/*"],
+      "@pages/*": ["./src/pages/*"],
+      "@Routes/*": ["./src/routes/*"],
+      "@Stores/*": ["./src/stores/*"],
+      "@Style/*": ["./src/style/*"],
+      "@Utils/*": ["./src/utils/*"],
+    }
   },
-  "include": [
-    "src"
-  ],
-  "typeRoots": [
-    "./@types",
-    "./node_modules/@types"
-  ]
+  "include": ["src"],
+  "typeRoots": ["./@types", "./node_modules/@types"]
 }
+

--- a/client/webpack/webpack.common.js
+++ b/client/webpack/webpack.common.js
@@ -7,6 +7,7 @@ const webpack = require("webpack");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const CopyPlugin = require("copy-webpack-plugin");
 const InterpolateHtmlPlugin = require("interpolate-html-plugin");
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 
 // IMAGE_INLINE_SIZE_LIMIT라는 환경변수 사용
 const imageInlineSizeLimit = process.env.IMAGE_INLINE_SIZE_LIMIT
@@ -25,17 +26,10 @@ module.exports = (_env) => {
     },
     resolve: {
       extensions: [".ts", ".tsx", ".js", ".jsx", ".json"],
-      alias: {
-        "@": path.resolve(__dirname, "src/"),
-        "@Route": path.resolve(__dirname, "src/route/"),
-        "@Pages": path.resolve(__dirname, "src/pages/"),
-        "@Components": path.resolve(__dirname, "src/components/"),
-        "@Style": path.resolve(__dirname, "public/scss/"),
-        "@Public": path.resolve(__dirname, "public/"),
-        "@Config": path.resolve(__dirname, "src/config/"),
-        "@Stores": path.resolve(__dirname, "src/store/stores/"),
-        "@types": path.resolve(__dirname, "../@types/"),
-      },
+      plugins: [new TsconfigPathsPlugin({
+        configFile: path.resolve(__dirname, "../tsconfig.json"),
+        baseUrl: path.resolve(__dirname, "../")
+      })],
     },
     module: {
       rules: [


### PR DESCRIPTION
## 주요 변경 사항
path alias 이름을 수정하고, vscode 자동완성도 가능하도록 수정하였습니다

## 코드 변경 이유
src 폴더내의 주요 폴더들에 대해 alias를 작성하였습니다.
alias를 통해 접근하면 자동완성이 안되는 불편함을 수정하기 위해
설정 내용을 tsconfig.json로 옮기고 tsconfig-paths-webpack-plugin를 사용하여 webpack에 적용하였습니다.

/src/assets/heart.svg에 총 3가지 방법으로 접근 가능합니다.
```js
// 상대경로로 접근
import * from './../../../../assets/heart.svg'
// `@`로 접근 base url => src/
import * from '@/assets/heart.svg'
// `@Assets`로 접근 base url => src/assets
import * from '@Assets/heart.svg'
```

## 코드 리뷰 시 중점적으로 봐야할 부분
- tsconfig.json 변경사함
- webpack.common.js 변경사항

## 연결된 이슈

## 자료 (스크린샷 등)
