### PR TITLE
fix: TagToCat PK 2개 오류 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCat.java
@@ -5,20 +5,21 @@ import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
-import javax.persistence.Entity;
-import javax.persistence.JoinColumn;
-import javax.persistence.ManyToOne;
+import javax.persistence.*;
 
 @Getter
 @Entity(name = "TAG_TO_CAT")
 @NoArgsConstructor
 @AllArgsConstructor
+@IdClass(TagToCatId.class)
 public class TagToCat {
+    @Id
     @ManyToOne
     @JoinColumn(name = "TAG_ID")
     @JsonBackReference
     private CatTag catTag;
 
+    @Id
     @ManyToOne
     @JoinColumn(name = "CAT_ID")
     @JsonBackReference

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCatId.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCatId.java
@@ -1,0 +1,9 @@
+package com.twentyfour_seven.catvillage.cat.entity;
+
+
+import java.io.Serializable;
+
+public class TagToCatId implements Serializable {
+    private CatTag catTag;
+    private Cat cat;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -34,8 +34,8 @@ public class CatService {
     }
 
     public Cat saveCat(Cat cat, String breed, List<CatTag> catTags) {
-        User user = userService.findVerifiedUser(userId);
-        cat.setUser(user);
+//        User user = userService.findVerifiedUser(userId);
+//        cat.setUser(user);
         Breed findBreed = breedService.findByBreedName(breed);
         cat.setBreed(findBreed);
         catTagService.saveTag(catTags, cat);


### PR DESCRIPTION
## 주요 변경 사항
- Serializable implements한 TagToCatId 클래스 생성 후 TagToCat의 Id 필드로 추가
- IdClass 애너테이션을 TagToCat에 추가
- issue #62 의 에러 일어나는 부분 주석 처리로 오류 방지 (해결 필요)

## 코드 변경 이유
build 과정에서 발생하는 오류 해결을 위해 코드 변경

## 코드 리뷰 시 중점적으로 봐야할 부분
- TagToCat
- TagToCatId

## 연결된 이슈
resolve #63 

## 자료 (스크린샷 등)
- 참고 블로그 : https://frogand.tistory.com/143