### PR TITLE
chore: script에서 jar 경로 변경

### DIFF
--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
-BUILD_JAR=$(ls /home/ubuntu/action/build/libs/catvillage-0.0.1-SNAPSHOT.jar)
+BUILD_JAR=$(ls /home/ubuntu/action/server/catvillage/build/libs/catvillage-0.0.1-SNAPSHOT.jar)
 JAR_NAME=$(basename $BUILD_JAR)
 
 echo "> 현재 시간: $(date)" >> /home/ubuntu/action/deploy.log


### PR DESCRIPTION
## 주요 변경 사항
- script의 build jar 경로가 달라서 수정

## 코드 변경 이유
- jar의 경로가 달라서 실행이 안되는 문제가 발생하여 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- 경로

## 연결된 이슈

## 자료 (스크린샷 등)
