### PR TITLE
feat: 유저 정보 보기, 변경, 회원 탈퇴 및 follow entity 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -69,4 +69,10 @@ public class UserController {
         User updateUser = userService.updateUser(user);
         return new ResponseEntity<>(userMapper.userToUserPatchResponseDto(updateUser), HttpStatus.OK);
     }
+
+    @DeleteMapping("/{user-id}/delete") // TODO : Security 적용 이후 "/delete"로 경로 변경 의논 필요
+    public ResponseEntity deleteUser(@PathVariable("user-id") Long userId) {
+        userService.removeUser(userId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -1,9 +1,12 @@
 package com.twentyfour_seven.catvillage.user.controller;
 
+import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.UserPatchDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.mapper.UserMapper;
 import com.twentyfour_seven.catvillage.user.service.UserService;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
@@ -11,6 +14,7 @@ import org.springframework.web.bind.annotation.*;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 
 @RestController
 @RequestMapping("/users")
@@ -36,5 +40,33 @@ public class UserController {
     public ResponseEntity getNameCheck(@RequestParam String name) {
         userService.nameDuplicateCheck(name);
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @GetMapping
+    public ResponseEntity getUsers(@RequestParam @Positive int page,
+                                   @RequestParam @Positive int size) {
+        Page<User> users = userService.findUsers(page - 1, size);
+
+        return new ResponseEntity<>(
+                new MultiResponseDto<>(
+                        userMapper.usersToUserGetResponseDtos(users.getContent()),
+                        users
+                ),
+                HttpStatus.OK
+        );
+    }
+
+    @GetMapping("/{user-id}")
+    public ResponseEntity getUser(@PathVariable("user-id") Long userId) {
+        User findUser = userService.findUser(userId);
+        return new ResponseEntity<>(userMapper.userToUserGetResponseDto(findUser), HttpStatus.OK);
+    }
+
+    @PatchMapping("/{user-id}")
+    public ResponseEntity patchUser(@PathVariable("user-id") Long userId,
+                                    @RequestBody UserPatchDto requestBody) {
+        User user = userMapper.userPatchDtoToUser(requestBody);
+        User updateUser = userService.updateUser(user);
+        return new ResponseEntity<>(userMapper.userToUserPatchResponseDto(updateUser), HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -64,7 +64,7 @@ public class UserController {
 
     @PatchMapping("/{user-id}")
     public ResponseEntity patchUser(@PathVariable("user-id") Long userId,
-                                    @RequestBody UserPatchDto requestBody) {
+                                    @Valid @RequestBody UserPatchDto requestBody) {
         User user = userMapper.userPatchDtoToUser(requestBody);
         User updateUser = userService.updateUser(user);
         return new ResponseEntity<>(userMapper.userToUserPatchResponseDto(updateUser), HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
@@ -1,0 +1,34 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserGetResponseDto {
+    private Long userId;
+    private String email;
+    private String name;
+    private String profileImage;
+    private String location;
+    private Integer catCount;
+    private Integer contentCount;
+    private Integer followingCount;
+    private Integer followerCount;
+
+    @Builder
+    public UserGetResponseDto(Long userId, String email, String name, String profileImage, String location, Integer catCount, Integer contentCount, Integer followingCount, Integer followerCount) {
+        this.userId = userId;
+        this.email = email;
+        this.name = name;
+        this.profileImage = profileImage;
+        this.location = location;
+        this.catCount = catCount;
+        this.contentCount = contentCount;
+        this.followingCount = followingCount;
+        this.followerCount = followerCount;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchDto.java
@@ -4,14 +4,19 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
 
 @Getter
 @Setter
 @NoArgsConstructor
 public class UserPatchDto {
+    @Length(max = 25)
     private String password;
+    @Length(max = 16)
     private String name;
+    @Length(max = 30)
     private String location;
+    @Length(max = 100)
     private String profileImage;
 
     @Builder

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchDto.java
@@ -1,0 +1,24 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class UserPatchDto {
+    private String password;
+    private String name;
+    private String location;
+    private String profileImage;
+
+    @Builder
+    public UserPatchDto(String password, String name, String location, String profileImage) {
+        this.password = password;
+        this.name = name;
+        this.location = location;
+        this.profileImage = profileImage;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserPatchResponseDto.java
@@ -1,0 +1,23 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@NoArgsConstructor
+public class UserPatchResponseDto {
+    private Long userId;
+    private String name;
+    private String location;
+    private String profileImage;
+
+    @Builder
+    public UserPatchResponseDto(Long userId, String name, String location, String profileImage) {
+        this.userId = userId;
+        this.name = name;
+        this.location = location;
+        this.profileImage = profileImage;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/Follow.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/Follow.java
@@ -1,0 +1,26 @@
+package com.twentyfour_seven.catvillage.user.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.Getter;
+
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.JoinColumn;
+import javax.persistence.ManyToOne;
+
+@Entity(name = "FOLLOW")
+@Getter
+public class Follow {
+    @Id
+    private Long followId;
+
+    @ManyToOne
+    @JoinColumn(name = "MEMBER_ID")
+    @JsonBackReference
+    private User memberId;
+
+    @ManyToOne
+    @JoinColumn(name = "TARGET_ID")
+    @JsonBackReference
+    private User targetId;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -1,13 +1,17 @@
 package com.twentyfour_seven.catvillage.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.twentyfour_seven.catvillage.audit.DateTable;
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.Setter;
 import net.minidev.json.annotate.JsonIgnore;
 
 import javax.persistence.*;
+import java.util.ArrayList;
 import java.util.Date;
+import java.util.List;
 
 @Entity(name = "USERS")
 @Getter
@@ -60,6 +64,18 @@ public class User extends DateTable {
     @Setter
     @Column(name = "EXPIRY_DATE")
     private Date expiryDate;
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "memberId", cascade = CascadeType.REMOVE)
+    private final List<Follow> following = new ArrayList<>();
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "targetId", cascade = CascadeType.REMOVE)
+    private final List<Follow> follower = new ArrayList<>();
+
+    @JsonManagedReference
+    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    private final List<Cat> cats = new ArrayList<>();
 
     public User() {
         catCount = 0;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
@@ -1,9 +1,10 @@
 package com.twentyfour_seven.catvillage.user.mapper;
 
-import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
-import com.twentyfour_seven.catvillage.user.dto.UserPostResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.*;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.mapstruct.Mapper;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring")
 public interface UserMapper {
@@ -31,6 +32,52 @@ public interface UserMapper {
                     .name(user.getName())
                     .profileImage(user.getProfileImage())
                     .location(user.getLocation())
+                    .build();
+        }
+    }
+
+    default UserGetResponseDto userToUserGetResponseDto(User user) {
+        if(user == null) {
+            return null;
+        } else {
+            return UserGetResponseDto.builder()
+                    .userId(user.getUserId())
+                    .email(user.getEmail())
+                    .name(user.getName())
+                    .profileImage(user.getProfileImage())
+                    .location(user.getLocation())
+                    .catCount(user.getCats().size())
+                    .contentCount(0) // TODO : edit after adding feed & board mapping
+                    .followerCount(user.getFollower().size())
+                    .followingCount(user.getFollowing().size())
+                    .build();
+        }
+    }
+
+    List<UserGetResponseDto> usersToUserGetResponseDtos(List<User> users);
+
+    default User userPatchDtoToUser(UserPatchDto requestBody) {
+        if(requestBody == null) {
+            return null;
+        } else {
+            return User.builder()
+                    .password(requestBody.getPassword())
+                    .name(requestBody.getName())
+                    .location(requestBody.getLocation())
+                    .profileImage(requestBody.getProfileImage())
+                    .build();
+        }
+    }
+
+    default UserPatchResponseDto userToUserPatchResponseDto(User user) {
+        if(user == null) {
+            return null;
+        } else {
+            return UserPatchResponseDto.builder()
+                    .userId(user.getUserId())
+                    .name(user.getName())
+                    .location(user.getLocation())
+                    .profileImage(user.getProfileImage())
                     .build();
         }
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -42,6 +42,7 @@ public class UserService {
     }
 
     public User updateUser(User user) {
+        verifiedExistedName(user.getName());
         User findUser = findVerifiedUser(user.getUserId());
         User updateUser = beanUtils.copyNonNullProperties(user, findUser);
         return userRepository.save(updateUser);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -4,6 +4,10 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.repository.UserRepository;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.Optional;
@@ -11,9 +15,11 @@ import java.util.Optional;
 @Service
 public class UserService {
     private UserRepository userRepository;
+    private CustomBeanUtils<User> beanUtils;
 
-    public UserService(UserRepository userRepository) {
+    public UserService(UserRepository userRepository, CustomBeanUtils<User> beanUtils) {
         this.userRepository = userRepository;
+        this.beanUtils = beanUtils;
     }
 
     public User createUser(User user) {
@@ -24,6 +30,21 @@ public class UserService {
 
     public void nameDuplicateCheck(String name) {
         verifiedExistedName(name);
+    }
+
+    public User findUser(Long userId) {
+        return findVerifiedUser(userId);
+    }
+
+    public Page<User> findUsers(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("userId").descending());
+        return userRepository.findAll(pageRequest);
+    }
+
+    public User updateUser(User user) {
+        User findUser = findVerifiedUser(user.getUserId());
+        User updateUser = beanUtils.copyNonNullProperties(user, findUser);
+        return userRepository.save(updateUser);
     }
 
     private User findVerifiedUser(Long id) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -47,6 +47,11 @@ public class UserService {
         return userRepository.save(updateUser);
     }
 
+    public void removeUser(Long userId) {
+        User findUser = findVerifiedUser(userId);
+        userRepository.delete(findUser);
+    }
+
     private User findVerifiedUser(Long id) {
         Optional<User> findUser = userRepository.findById(id);
         return findUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));


### PR DESCRIPTION
## 주요 변경 사항
- 유저 정보 보기 및 변경 API 추가
- Follow 기능 구현을 위한 entity 추가
- User entity에 Follow 및 Cat entity 연관관계 매핑
- 유저 정보 중 contentCount는 추후 feed, board 연관관계 매핑 후 구현 필요
- 회원 탈퇴 기능 추가

## 코드 변경 이유
- 유저 정보 보기 API 추가 및 이를 위한 UserGetResponseDto 추가
- 유저 정보 수정 API 추가 및 이를 위한 UserPatchDot, UserPatchResponseDto 추가 및 UserPatchDto에 validation 적용
- 회원 탈퇴 API 추가
- 추가된 Dto의 변환을 위한 UserMapper interface에 default method 및 abstract method 추가
- Follow 기능 구현을 위한 Follow class 추가
- User class에서 Follow 및 Cat 정보를 얻기 위한 연관관계 매핑
- User class에서 Follow 및 Cat의 연관관계에 Casecade remove 적용
- 유저 정보의 name은 유니크 값이므로 유저 정보 수정 시 name의 중복 값 여부를 확인하는 로직 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- UserController class
- UserPatchDto class
- Follow class
- User class
- UserMapper interface
- UserService class

## 연결된 이슈
solved #20
solved #21
solved #68 

## 자료 (스크린샷 등)
