### PR TITLE
fix: lint 관련 수정사항 반영

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -38,5 +38,6 @@ module.exports = {
       2,
       { namedComponents: 'arrow-function' }, // 함수형 컴포넌트 형식 정의
     ],
+    "react/require-default-props": "off" 
   }
 }

--- a/client/.prettierrc.js
+++ b/client/.prettierrc.js
@@ -4,6 +4,6 @@ module.exports = {
   useTabs: false, //탭의 사용을 금하고 스페이스바 사용으로 대체하게 formatting
   tabWidth: 2, // 들여쓰기 너비는 2칸
   trailingComma: 'all', // 자세한 설명은 구글링이 짱이긴하나 객체나 배열 키:값 뒤에 항상 콤마를 붙히도록 formatting
-  printWidth: 120, // 코드 한줄이 maximum 80칸
+  printWidth: 80, // 코드 한줄이 maximum 80칸
   arrowParens: 'avoid', // 화살표 함수가 하나의 매개변수를 받을 때 괄호를 생략하게 formatting
 }

--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -16,10 +16,12 @@
     "jsx": "react-jsx",
     "baseUrl": ".",
     "paths": {
-      "@/*": ["./src/*"],
       "@Types/*": ["./src/@types/*"],
       "@Api/*": ["./src/api/*"],
       "@Assets/*": ["./src/assets/*"],
+      "@Atoms/*": ["./src/components/atoms/*"],
+      "@Modules/*": ["./src/components/modules/*"],
+      "@Template/*": ["./src/components/template/*"],
       "@Components/*": ["./src/components/*"],
       "@Hooks/*": ["./src/hooks/*"],
       "@Layout/*": ["./src/layout/*"],
@@ -28,6 +30,7 @@
       "@Stores/*": ["./src/stores/*"],
       "@Style/*": ["./src/style/*"],
       "@Utils/*": ["./src/utils/*"],
+      "@/*": ["./src/*"],
     }
   },
   "include": ["src"],


### PR DESCRIPTION
## 주요 변경 사항
개발과정에서 발견된 필요한 lint관련 수정사항 들을 반영하였습니다.

## 코드 변경 이유
1. 코드 한줄이 80줄이 넘지 않도록 .prettier.js를 수정하였습니다.
    - 변경사항: [1d71caa](https://github.com/codestates-seb/seb39_main_059/commit/1d71caa27176bce4b1d75f445433e27f5474b022)
3. react/require-default-props 규칙 무시하도록 하였습니다.
     - 변경사항: [c8f97b6](https://github.com/codestates-seb/seb39_main_059/commit/c8f97b629f2aca6e8d4839e3bfabfba047c8f1f0)
5. paths 속성에서 "@/*"가  앞에있어서 뒤의 자동완성에서 뒤쪽에 alias가 
적용되지 않는 문제가 있었습니다.
    따라서 순서를 맨뒤에 옮겨 주었습니다.
    또한 atoms, modules, template의 alias를 추가해주었습니다.
     - 변경사항: [d8d9f65](https://github.com/codestates-seb/seb39_main_059/commit/d8d9f65ef47b6d672584753849185fa27d7a9a40)

## 코드 리뷰 시 중점적으로 봐야할 부분
이부분을 지우고 내용을 적어주세요.

## 연결된 이슈

## 자료 (스크린샷 등)
