### PR TITLE
feat: 카카오 OAuth2 인증을 위한 코드 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/CustomOAuth2UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/CustomOAuth2UserService.java
@@ -1,0 +1,83 @@
+package com.twentyfour_seven.catvillage.security;
+
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import com.twentyfour_seven.catvillage.user.dto.SessionUser;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import javax.servlet.http.HttpSession;
+import java.util.Collections;
+import java.util.Optional;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+    private final UserRepository userRepository;
+    private final HttpSession httpSession;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2UserService<OAuth2UserRequest, OAuth2User> delegate = new DefaultOAuth2UserService();
+        OAuth2User oAuth2User = delegate.loadUser(userRequest);
+
+        // OAuth2 Service ID (google, kakao, naver)
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // OAuth2 로그인 진행 시 키가 되는 필드 값(PK)
+        String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // OAuth2UserService
+        OAuthAttributes authAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+        User user = saveOfUpdate(authAttributes);
+        httpSession.setAttribute("user", new SessionUser(user));    // 직렬화된 dto 클래스 사용
+
+        return new DefaultOAuth2User(
+                Collections.singleton(new SimpleGrantedAuthority(user.getRole())),
+                authAttributes.getAttributes(),
+                authAttributes.getNameAttributeKey());
+    }
+
+    private User saveOfUpdate(OAuthAttributes authAttributes) {
+        // name은 유니크 값이기 때문에 중복인 경우 뒤에 추가로 숫자를 붙혀서 생성
+        // 이미 가입된 경우도 존재하기 때문에 email 동일 여부 확인 후 진행
+        String name = authAttributes.getName();
+        Optional<User> findUser = userRepository.findByName(name);
+        long count = 0;
+        while(findUser.isPresent()) {
+            if(!findUser.get().getEmail().equals(authAttributes.getEmail())) {
+                findUser = userRepository.findByName(name + ++count);
+            } else {
+                break;
+            }
+        }
+        // 중복값이 없다면 패스
+        if(count > 0) {
+            name = authAttributes.getName() + count;
+        }
+
+        // 비밀번호가 있다면 일반 회원 가입 한 유저이므로 예외 처리
+        if(findUser.isPresent()) {
+            if(findUser.get().getPassword() != null) {
+                throw new BusinessLogicException(ExceptionCode.MEMBER_EMAIL_EXISTS);
+            }
+        }
+
+        String finalName = name;
+        User user = userRepository.findByEmail(authAttributes.getEmail())
+                .map(entry -> { // 계정이 존재 한다면, 이름과 프로필 이미지를 업데이트
+                    entry.setName(finalName);
+                    entry.setProfileImage(authAttributes.getPicture());
+                    return entry;
+                }).orElse(authAttributes.toEntity());
+        return userRepository.save(user);
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/OAuthAttributes.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/OAuthAttributes.java
@@ -1,0 +1,55 @@
+package com.twentyfour_seven.catvillage.security;
+
+import com.twentyfour_seven.catvillage.user.entity.User;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+public class OAuthAttributes {
+    private Map<String, Object> attributes; // OAuth2 반환 유저 정보
+    private String nameAttributeKey;
+    private String name;
+    private String email;
+    private String picture;
+
+    @Builder
+    public OAuthAttributes(Map<String, Object> attributes, String nameAttributeKey, String name, String email, String picture) {
+        this.attributes = attributes;
+        this.nameAttributeKey = nameAttributeKey;
+        this.name = name;
+        this.email = email;
+        this.picture = picture;
+    }
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        return ofKakao("id", attributes);
+    }
+
+    private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
+        // kakao_account에 profile, email 정보 포함
+        Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+        // profile에 nickname, profile_image 정보 포함
+        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("prfile");
+
+        return OAuthAttributes.builder()
+                .name((String) kakaoProfile.get("nickname"))
+                .email((String) kakaoAccount.get("email"))
+                .picture((String) kakaoProfile.get("profile_image_url"))
+                .attributes(attributes)
+                .nameAttributeKey(userNameAttributeName)
+                .build();
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .name(name)
+                .email(email)
+                .password(picture)
+                .role("ROLE_USER")
+                .build();
+    }
+
+
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/SessionUser.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/SessionUser.java
@@ -1,0 +1,19 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import com.twentyfour_seven.catvillage.user.entity.User;
+import lombok.Getter;
+
+import java.io.Serializable;
+
+@Getter
+public class SessionUser implements Serializable {
+    private String name;
+    private String email;
+    private String picture;
+
+    public SessionUser(User user) {
+        this.name = user.getName();
+        this.email = user.getEmail();
+        this.picture = user.getProfileImage();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -25,7 +25,8 @@ public class User extends DateTable {
     private String email;
 
     @Setter
-    @Column(name = "PASSWORD", nullable = false, length = 25)
+//    @Column(name = "PASSWORD", nullable = false, length = 25)
+    @Column(name = "PASSWORD", length = 25)
     @JsonIgnore
     private String password;
 


### PR DESCRIPTION
## 주요 변경 사항
- 카카오 OAuth2.0 인증을 위한 코드 추가
- user의 password 컬럼 nullalbe true로 변경

## 코드 변경 이유
- OAuth 인증으로 회원가입을 하는 유저들은 password가 따로 없기에 null로 저장되기 때문에 nullable true 필요

## 코드 리뷰 시 중점적으로 봐야할 부분
- CustomOAuth2UserService class
- OAuthAttributes class
- SessionUser class : 직렬화를 위한 DTO 클래스

## 연결된 이슈

## 자료 (스크린샷 등)
