### PR TITLE
feat: 전역에서 Noto Sans KR font 적용

### DIFF
--- a/client/public/index.html
+++ b/client/public/index.html
@@ -13,7 +13,7 @@
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>React App</title>
     <style>
-      @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
+      @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@500;600&display=swap');
     </style>
   </head>
   <body>

--- a/client/public/index.html
+++ b/client/public/index.html
@@ -12,6 +12,9 @@
     <link rel="apple-touch-icon" href="%PUBLIC_URL%/logo192.png" />
     <link rel="manifest" href="%PUBLIC_URL%/manifest.json" />
     <title>React App</title>
+    <style>
+      @import url('https://fonts.googleapis.com/css2?family=Noto+Sans+KR:wght@400;500;700&display=swap');
+    </style>
   </head>
   <body>
     <noscript>You need to enable JavaScript to run this app.</noscript>

--- a/client/src/styles/GlobalStyle.ts
+++ b/client/src/styles/GlobalStyle.ts
@@ -9,7 +9,7 @@ export const GlobalStyle = createGlobalStyle`
   }
 
   html, body {
-    font-family: -apple-system,BlinkMacSystemFont,"Segoe UI Adjusted","Segoe UI","Liberation Sans",sans-serif;
+    font-family: 'Noto Sans KR', sans-serif !important;
   }
 
   body {


### PR DESCRIPTION
## 주요 변경 사항
앱 전역에서 Noto Sans KR font 적용하도록 변경하였습니다.

## 코드 변경 이유
디자인 상으로 앱 전역에서 Noto Sans를 사용하기 때문에 
1. public/index.html에서 google font를 통해 해당 font를 불러오고 
2. body tag 내에서  Noto Sans KR font를 적용시켜 주었습니다.

- 디자인 안에서 사용되는 font-weigth인 500, 600만 불러오도록 설정해주었습니다. 만약 다른 font-weight가 사용되어야 한다면 코드 변경이 필요할 수 있습니다.
## 코드 리뷰 시 중점적으로 봐야할 부분
이부분을 지우고 내용을 적어주세요.

## 연결된 이슈

## 자료 (스크린샷 등)
