### PR TITLE
fix: security 설정 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
@@ -39,7 +39,9 @@ public class SecurityConfig {
                 .headers()
                 .frameOptions()
                 .sameOrigin()
-                // TODO: formLogin 관련 설정 필요
+                .and()
+                .formLogin()
+                .loginProcessingUrl("/login")
                 .and()
                 .addFilter(corsFilter)
                 .sessionManagement().sessionCreationPolicy(SessionCreationPolicy.STATELESS)

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
@@ -49,17 +49,12 @@ public class JwtTokenizer {
     // accessToken 생성
     public String generateAccessToken(Authentication authentication) {
         // claim 생성
-        String authority = "";
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
-        if (authorities.startsWith("ROLE_USER")) {
-            authority = "ROLE_USER";
-        } else if (authorities.startsWith("ROLE_ADMIN")) {
-            authority = "ROLE_ADMIN";
-        }
+
         Map<String, String> claims = new HashMap<>();
-        claims.put("auth", authority);
+        claims.put("auth", authorities);
 
         long now = (new Date()).getTime();
 
@@ -107,7 +102,6 @@ public class JwtTokenizer {
             throw new RuntimeException("권한 정보가 없는 토큰입니다.");
         }
 
-        // claim에서 권한 정보 가져오기
         // 클레임에서 권한 정보 가져오기
         Collection<? extends GrantedAuthority> authorities =
                 Arrays.stream(claims.get("auth").toString().split(","))


### PR DESCRIPTION
## 주요 변경 사항
- securityConfig 파일에 formLogin 및 loginProcessingUrl 추가
- JwtTokenizer에 role 하나만 넣던 로직을 여러개 받을 수 있도록 수정

## 코드 변경 이유
- formLogin 부분이 TODO 주석 처리 되어있어서 주석 제거하고 설정해주었습니다.
- formLogin 사용 시 인증 실패, 성공에 따른 redirection은 프론트에서 처리하는것이 적절하여 로그인 요청하는 경로(loginProcessingUrl)만 설정해주었습니다.
- jwt를 생성하는 부분에서 인가 정보를 Collection으로 저장하는데 role을 하나만 넣던 것을 편의성을 위해 여러개 넣을 수 있도록 확장했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈
- #90 

## 자료 (스크린샷 등)
