### PR TITLE
fix: User 카운트 관련 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
@@ -15,12 +15,12 @@ public class UserGetResponseDto {
     private String profileImage;
     private String location;
     private Integer catCount;
-    private Integer contentCount;
-    private Integer followingCount;
-    private Integer followerCount;
+    private Long contentCount;
+    private Long followingCount;
+    private Long followerCount;
 
     @Builder
-    public UserGetResponseDto(Long userId, String email, String name, String profileImage, String location, Integer catCount, Integer contentCount, Integer followingCount, Integer followerCount) {
+    public UserGetResponseDto(Long userId, String email, String name, String profileImage, String location, Integer catCount, Long contentCount, Long followingCount, Long followerCount) {
         this.userId = userId;
         this.email = email;
         this.name = name;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -42,10 +42,6 @@ public class User extends DateTable {
     private String location;
 
     @Setter
-    @Column(name = "CAT_COUNT")
-    private long catCount;
-
-    @Setter
     @Column(name = "CONTENT_COUNT")
     private long contentCount;
 
@@ -78,7 +74,6 @@ public class User extends DateTable {
     private final List<Cat> cats = new ArrayList<>();
 
     public User() {
-        catCount = 0;
         contentCount = 0;
         followerCount = 0;
         followingCount = 0;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
@@ -49,9 +49,9 @@ public interface UserMapper {
                     .profileImage(user.getProfileImage())
                     .location(user.getLocation())
                     .catCount(user.getCats().size())
-                    .contentCount(0) // TODO : edit after adding feed & board mapping
-                    .followerCount(user.getFollower().size())
-                    .followingCount(user.getFollowing().size())
+                    .contentCount(user.getContentCount()) // TODO : edit after adding feed & board mapping
+                    .followerCount(user.getFollowerCount())
+                    .followingCount(user.getFollowingCount())
                     .build();
         }
     }


### PR DESCRIPTION
## 주요 변경 사항
- User entity에 catCount 제거
- 위 수정으로 인한 mapper 로직 및 dto 수정

## 코드 변경 이유
- count 컬럼 중 catCount만 사용을 안하기로 했기에 제거
- 위 수정으로 인한 response dto 수정 및 mapper 로직 수정
- response dto에서 catCount를 제외한 나머지 count 컬럼들의 타입을 Integer -> Long으로 변경

## 코드 리뷰 시 중점적으로 봐야할 부분
- User entity에서 catCount 제외
- UserGetResponseDto class에서 count 컬럼들의 타입 변경
- UserMapper interface에서 userToUserGetResponseDto default method의 로직 수정 코드

## 연결된 이슈
fixed #73

## 자료 (스크린샷 등)
