### PR TITLE
feat: Picture 필수 클래스 및 저장 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
@@ -1,0 +1,40 @@
+package com.twentyfour_seven.catvillage.common.picture.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.validator.constraints.Length;
+
+import javax.persistence.*;
+
+@Entity(name = "PICTURE")
+@Getter
+@NoArgsConstructor
+public class Picture {
+    @Id
+    @Column(name = "PICTURE_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long pictureId;
+
+    // TODO: Feed entity 추가 후 주석 제거 필요
+//    @ManyToOne
+//    @JoinColumn(name = "FEED_ID")
+//    @JsonBackReference
+//    private Feed feedId;
+
+    // TODO: Board entity 추가 후 주석 제거 필요
+//    @ManyToOne
+//    @JoinColumn(name = "BOARD_ID")
+//    @JsonBackReference
+//    private Board boardId;
+
+    @Column(name = "PATH", length = 100)
+    private String path;
+
+    @Builder
+    public Picture(Long pictureId, String path) {
+        this.pictureId = pictureId;
+        this.path = path;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/repository/PictureRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/repository/PictureRepository.java
@@ -1,0 +1,10 @@
+package com.twentyfour_seven.catvillage.common.picture.repository;
+
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface PictureRepository extends JpaRepository<Picture, Long> {
+    Optional<Picture> findByPath(String path);
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/PictureService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/PictureService.java
@@ -1,0 +1,37 @@
+package com.twentyfour_seven.catvillage.common.picture.service;
+
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import com.twentyfour_seven.catvillage.common.picture.repository.PictureRepository;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class PictureService {
+    private PictureRepository pictureRepository;
+
+    public PictureService(PictureRepository pictureRepository) {
+        this.pictureRepository = pictureRepository;
+    }
+
+    public Picture createPicture(Picture picture) {
+        return pictureRepository.save(picture);
+    }
+
+    public void removePicture(Long pictureId) {
+        Picture findPicture = findVerifiedPicture(pictureId);
+        pictureRepository.delete(findPicture);
+    }
+
+    private Picture findVerifiedPicture(Long pictureId) {
+        Optional<Picture> findPicture = pictureRepository.findById(pictureId);
+        return findPicture.orElseThrow(() -> new BusinessLogicException(ExceptionCode.PICTURE_NOT_FOUND));
+    }
+
+    private Picture findVerifiedPath(String path) {
+        Optional<Picture> findPicture = pictureRepository.findByPath(path);
+        return findPicture.orElseThrow(() -> new BusinessLogicException(ExceptionCode.PICTURE_NOT_FOUND));
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -7,7 +7,8 @@ public enum ExceptionCode {
     MEMBER_EMAIL_EXISTS(409, "Email address already in use"),
     MEMBER_NAME_EXISTS(409, "Name already in use"),
     BREED_NOT_FOUND(404, "Breed not found"),
-    CAT_NOT_FOUND(409, "Cat not found");
+    CAT_NOT_FOUND(409, "Cat not found"),
+    PICTURE_NOT_FOUND(409, "Picture not found");
 
     @Getter
     private final int status;


### PR DESCRIPTION
## 주요 변경 사항
- Picture entity 구현, feed 및 board entity 구현 후 연관관계 맵핑 필요
- Picture repository 구현, path로 데이터를 찾는 메서드 추가
- Picture service 구현, 저장 및 pictureId로 삭제하는 메서드 구현
- Picture not found 예외 추가

## 코드 변경 이유
- Feed(냥이생활) 및 Board(집사생활)에서 공용으로 사용할 Picture(사진) Entity 추가
- Picture 저장 기능 구현
- Picture ID로 삭제하는 기능 구현
- Repository에 path로 데이터를 조회하는 메서드 추가
- Picture 조회 시 존재하지 않는 경우, 예외 처리를 위하여 PICTURE_NOT_FOUND 예외 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- Picture entity
- PictureRepository interface
- PictureService class
- ExceptionCode enum

## 연결된 이슈
solved #114
solved #115

## 자료 (스크린샷 등)
