### PR TITLE
feat: Board comment 및 Board Tag 관련 클래스 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,18 +1,31 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
+import com.twentyfour_seven.catvillage.board.entity.BoardComment;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
+import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
+import com.twentyfour_seven.catvillage.board.service.BoardTagService;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.transaction.Transactional;
+
 @RestController
 @RequestMapping("/집사생활")
+@Transactional
+@Validated
 public class BoardController {
     private BoardMapper boardMapper;
     private BoardService boardService;
+    private BoardCommentService boardCommentService;
+    private BoardTagService boardTagService;
 
-    public BoardController(BoardMapper boardMapper, BoardService boardService) {
+    public BoardController(BoardMapper boardMapper, BoardService boardService, BoardCommentService boardCommentService, BoardTagService boardTagService) {
         this.boardMapper = boardMapper;
         this.boardService = boardService;
+        this.boardCommentService = boardCommentService;
+        this.boardTagService = boardTagService;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
@@ -14,7 +14,7 @@ import javax.persistence.*;
 import java.util.ArrayList;
 import java.util.List;
 
-@Entity
+@Entity(name = "BOARD")
 @Getter
 public class Board extends DateTable {
     @Id
@@ -51,6 +51,24 @@ public class Board extends DateTable {
     @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<Picture> pictures = new ArrayList<>();
+
+    @OneToMany(mappedBy = "boardID", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private final List<BoardComment> boardComments = new ArrayList<>();
+
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private final List<TagToBoard> tagToBoards = new ArrayList<>();
+
+    // TODO: Like 구현 후 주석 제거 필요
+//    @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
+//    @JsonManagedReference
+//    private final List<Like> likes = new ArrayList<>();
+
+    // TODO: Save 구현 후 주석 제거 필요
+//    @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
+//    @JsonManagedReference
+//    private final List<Save> saves = new ArrayList<>();
 
     public Board() {
         likeCount = 0L;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
@@ -83,10 +83,10 @@ public class Board extends DateTable {
     }
 
     @Builder
-    public Board(Long boardId, User userId, String title, String body) {
+    public Board(Long boardId, User user, String title, String body) {
         this();
         this.boardId = boardId;
-        this.userId = userId;
+        this.user = user;
         this.title = title;
         this.body = body;
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/Board.java
@@ -26,7 +26,7 @@ public class Board extends DateTable {
     @JoinColumn(name = "USER_ID")
     @JsonBackReference
     @Setter
-    private User userId;
+    private User user;
 
     @Setter
     @Column(name = "TITLE", length = 64, nullable = false)
@@ -48,11 +48,11 @@ public class Board extends DateTable {
     @Column(name = "COMMENT_COUNT", nullable = false)
     private Long commentCount;
 
-    @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<Picture> pictures = new ArrayList<>();
 
-    @OneToMany(mappedBy = "boardID", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<BoardComment> boardComments = new ArrayList<>();
 
@@ -61,12 +61,12 @@ public class Board extends DateTable {
     private final List<TagToBoard> tagToBoards = new ArrayList<>();
 
     // TODO: Like 구현 후 주석 제거 필요
-//    @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
+//    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
 //    @JsonManagedReference
 //    private final List<Like> likes = new ArrayList<>();
 
     // TODO: Save 구현 후 주석 제거 필요
-//    @OneToMany(mappedBy = "boardId", cascade = CascadeType.REMOVE)
+//    @OneToMany(mappedBy = "board", cascade = CascadeType.REMOVE)
 //    @JsonManagedReference
 //    private final List<Save> saves = new ArrayList<>();
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
@@ -1,0 +1,35 @@
+package com.twentyfour_seven.catvillage.board.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import com.twentyfour_seven.catvillage.audit.DateTable;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@NoArgsConstructor
+@Entity(name = "BOARD_COMMENT")
+public class BoardComment extends DateTable {
+    @Id
+    @Column(name = "BOARD_COMMENT_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long boardCommentId;
+
+    @ManyToOne
+    @JoinColumn(name = "BOARD_ID")
+    @JsonBackReference
+    private Board boardId;
+
+    @ManyToOne
+    @JoinColumn(name = "USER_ID")
+    @JsonBackReference
+    private User userId;
+
+    @Column(name = "BODY", length = 500, nullable = false)
+    private String body;
+
+    @Column(name = "LIKE_COUNT", nullable = false)
+    private Long likeCount;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
@@ -3,6 +3,7 @@ package com.twentyfour_seven.catvillage.board.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.twentyfour_seven.catvillage.audit.DateTable;
 import com.twentyfour_seven.catvillage.user.entity.User;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -32,4 +33,13 @@ public class BoardComment extends DateTable {
 
     @Column(name = "LIKE_COUNT", nullable = false)
     private Long likeCount;
+
+    @Builder
+    public BoardComment(Long boardCommentId, Board board, User user, String body, Long likeCount) {
+        this.boardCommentId = boardCommentId;
+        this.board = board;
+        this.user = user;
+        this.body = body;
+        this.likeCount = likeCount;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardComment.java
@@ -20,12 +20,12 @@ public class BoardComment extends DateTable {
     @ManyToOne
     @JoinColumn(name = "BOARD_ID")
     @JsonBackReference
-    private Board boardId;
+    private Board board;
 
     @ManyToOne
     @JoinColumn(name = "USER_ID")
     @JsonBackReference
-    private User userId;
+    private User user;
 
     @Column(name = "BODY", length = 500, nullable = false)
     private String body;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
@@ -1,6 +1,7 @@
 package com.twentyfour_seven.catvillage.board.entity;
 
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
@@ -23,4 +24,10 @@ public class BoardTag {
     @OneToMany(mappedBy = "boardTag", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<TagToBoard> tagToBoards = new ArrayList<>();
+
+    @Builder
+    public BoardTag(Long boardTagId, String tagName) {
+        this.boardTagId = boardTagId;
+        this.tagName = tagName;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
@@ -1,0 +1,26 @@
+package com.twentyfour_seven.catvillage.board.entity;
+
+import com.fasterxml.jackson.annotation.JsonManagedReference;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Entity(name = "BOARD_TAG")
+@NoArgsConstructor
+public class BoardTag {
+    @Id
+    @Column(name = "BOARD_TAG_ID")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long boardTagId;
+
+    @Column(name = "TAG_NAME", length = 15, nullable = false)
+    private String tagName;
+
+    @OneToMany(mappedBy = "boardTag", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private final List<TagToBoard> tagToBoards = new ArrayList<>();
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoard.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoard.java
@@ -1,0 +1,32 @@
+package com.twentyfour_seven.catvillage.board.entity;
+
+import com.fasterxml.jackson.annotation.JsonBackReference;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import javax.persistence.*;
+
+@Getter
+@Entity(name = "TAG_TO_BOARD")
+@NoArgsConstructor
+@IdClass(TagToBoardId.class)
+public class TagToBoard {
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "BOARD_ID")
+    @JsonBackReference
+    private Board board;
+
+    @Id
+    @ManyToOne
+    @JoinColumn(name = "BOARD_TAG_ID")
+    @JsonBackReference
+    private BoardTag boardTag;
+
+    @Builder
+    public TagToBoard(Board board, BoardTag boardTag) {
+        this.board = board;
+        this.boardTag = boardTag;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoardId.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoardId.java
@@ -1,0 +1,15 @@
+package com.twentyfour_seven.catvillage.board.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.io.Serializable;
+
+@Data
+@NoArgsConstructor
+@AllArgsConstructor
+public class TagToBoardId implements Serializable {
+    private Board board;
+    private BoardTag boardTag;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardCommentRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardCommentRepository.java
@@ -1,0 +1,7 @@
+package com.twentyfour_seven.catvillage.board.repository;
+
+import com.twentyfour_seven.catvillage.board.entity.BoardComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardCommentRepository extends JpaRepository<BoardComment, Long> {
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardTagRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardTagRepository.java
@@ -1,0 +1,7 @@
+package com.twentyfour_seven.catvillage.board.repository;
+
+import com.twentyfour_seven.catvillage.board.entity.BoardTag;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/TagToBoardRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/TagToBoardRepository.java
@@ -1,0 +1,8 @@
+package com.twentyfour_seven.catvillage.board.repository;
+
+import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
+import com.twentyfour_seven.catvillage.board.entity.TagToBoardId;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TagToBoardRepository extends JpaRepository<TagToBoard, TagToBoardId> {
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardCommentService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardCommentService.java
@@ -1,0 +1,17 @@
+package com.twentyfour_seven.catvillage.board.service;
+
+import com.twentyfour_seven.catvillage.board.entity.BoardComment;
+import com.twentyfour_seven.catvillage.board.repository.BoardCommentRepository;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BoardCommentService {
+    private BoardCommentRepository boardCommentRepository;
+    private CustomBeanUtils<BoardComment> beanUtils;
+
+    public BoardCommentService(BoardCommentRepository boardCommentRepository, CustomBeanUtils<BoardComment> beanUtils) {
+        this.boardCommentRepository = boardCommentRepository;
+        this.beanUtils = beanUtils;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -1,13 +1,17 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.repository.BoardRepository;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
 
 @Service
 public class BoardService {
     private BoardRepository boardRepository;
+    private CustomBeanUtils<Board> beanUtils;
 
-    public BoardService(BoardRepository boardRepository) {
+    public BoardService(BoardRepository boardRepository, CustomBeanUtils<Board> beanUtils) {
         this.boardRepository = boardRepository;
+        this.beanUtils = beanUtils;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
@@ -1,0 +1,13 @@
+package com.twentyfour_seven.catvillage.board.service;
+
+import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class BoardTagService {
+    private BoardTagRepository boardTagRepository;
+
+    public BoardTagService(BoardTagRepository boardTagRepository) {
+        this.boardTagRepository = boardTagRepository;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
@@ -1,0 +1,13 @@
+package com.twentyfour_seven.catvillage.board.service;
+
+import com.twentyfour_seven.catvillage.board.repository.TagToBoardRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+public class TagToBoardService {
+    private TagToBoardRepository tagToBoardRepository;
+
+    public TagToBoardService(TagToBoardRepository tagToBoardRepository) {
+        this.tagToBoardRepository = tagToBoardRepository;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
@@ -27,7 +27,7 @@ public class Picture {
     @ManyToOne
     @JoinColumn(name = "BOARD_ID")
     @JsonBackReference
-    private Board boardId;
+    private Board board;
 
     @Column(name = "PATH", length = 100)
     private String path;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/Follow.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/Follow.java
@@ -17,10 +17,10 @@ public class Follow {
     @ManyToOne
     @JoinColumn(name = "MEMBER_ID")
     @JsonBackReference
-    private User memberId;
+    private User member;
 
     @ManyToOne
     @JoinColumn(name = "TARGET_ID")
     @JsonBackReference
-    private User targetId;
+    private User target;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -66,11 +66,11 @@ public class User extends DateTable {
     @Column(name = "EXPIRY_DATE")
     private Date expiryDate;
 
-    @OneToMany(mappedBy = "memberId", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "member", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<Follow> following = new ArrayList<>();
 
-    @OneToMany(mappedBy = "targetId", cascade = CascadeType.REMOVE)
+    @OneToMany(mappedBy = "target", cascade = CascadeType.REMOVE)
     @JsonManagedReference
     private final List<Follow> follower = new ArrayList<>();
 
@@ -82,16 +82,15 @@ public class User extends DateTable {
     @JsonManagedReference
     private final List<Feed> feeds = new ArrayList<>();
 
-    @Setter
     @JsonManagedReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private final List<FeedComment> feedComments = new ArrayList<>();
 
-    @OneToMany(mappedBy = "userId")
+    @OneToMany(mappedBy = "user")
     @JsonManagedReference
     private final List<Board> boards = new ArrayList<>();
 
-    @OneToMany(mappedBy = "userId")
+    @OneToMany(mappedBy = "user")
     @JsonManagedReference
     private final List<BoardComment> boardComments = new ArrayList<>();
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -1,7 +1,10 @@
 package com.twentyfour_seven.catvillage.user.entity;
 
+import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.twentyfour_seven.catvillage.audit.DateTable;
+import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.board.entity.BoardComment;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import lombok.Builder;
 import lombok.Getter;
@@ -61,17 +64,25 @@ public class User extends DateTable {
     @Column(name = "EXPIRY_DATE")
     private Date expiryDate;
 
-    @JsonManagedReference
     @OneToMany(mappedBy = "memberId", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
     private final List<Follow> following = new ArrayList<>();
 
-    @JsonManagedReference
     @OneToMany(mappedBy = "targetId", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
     private final List<Follow> follower = new ArrayList<>();
 
-    @JsonManagedReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
     private final List<Cat> cats = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userId")
+    @JsonManagedReference
+    private final List<Board> boards = new ArrayList<>();
+
+    @OneToMany(mappedBy = "userId")
+    @JsonManagedReference
+    private final List<BoardComment> boardComments = new ArrayList<>();
 
     public User() {
         contentCount = 0;


### PR DESCRIPTION
## 주요 변경 사항
- Board comment(집사생활 댓글) 관련 클래스 및 인터페이스 추가
- Board tag(집사생활 태그) 관련 클래스 및 인터페이스 추가

## 코드 변경 이유
- 집사생활 게시글에 작성할 수 있는 댓글을 구현하기 위해 수정
- 집사생활 게시글에 태그를 지정하는 기능을 구현하기 위해 수정
- 각각의 엔티티의 연관관계 매핑 코드도 추가
- Boarder와 BoarderTag를 복합키로 사용하는 TagToBoader를 위한 복합키 클래스 TagToBoaderIdId를 구현하여 사용

## 코드 리뷰 시 중점적으로 봐야할 부분
- User class, 연관관계 매핑
- Boarder class, 연관관계 매핑
- BoaderComment class
- BoardTag class
- TagToBoarder class
- TagToBoarderId class

## 연결된 이슈

## 자료 (스크린샷 등)
