### PR TITLE
feat: 냥이생활 피드 작성하기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
@@ -2,6 +2,7 @@ package com.twentyfour_seven.catvillage.cat.entity;
 
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
+import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import lombok.Builder;
 import lombok.Getter;
@@ -45,6 +46,10 @@ public class Cat {
     @JoinColumn(name = "USER_ID")
     @JsonBackReference
     private User user;
+
+    @OneToMany(mappedBy = "cat", cascade = CascadeType.REMOVE)
+    @JsonManagedReference
+    private final List<Feed> feeds = new ArrayList<>();
 
     // TODO: CatInfo 구현 후 주석 제거 필요
 //    @Setter

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
@@ -1,0 +1,17 @@
+package com.twentyfour_seven.catvillage.common.picture.dto;
+
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PictureDto {
+    private String picture;
+
+    public PictureDto(Picture picture) {
+        this.picture = picture.getPath();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -1,11 +1,24 @@
 package com.twentyfour_seven.catvillage.feed.controller;
 
+import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
+import com.twentyfour_seven.catvillage.feed.entity.Feed;
+import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
 import com.twentyfour_seven.catvillage.feed.mapper.FeedMapper;
+import com.twentyfour_seven.catvillage.feed.mapper.FeedTagMapper;
+import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
+import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/냥이생활")
@@ -13,10 +26,28 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class FeedController {
     private final FeedService feedService;
+    private final FeedCommentService feedCommentService;
+    private final FeedTagService feedTagService;
     private final FeedMapper feedMapper;
+    private final FeedTagMapper feedTagMapper;
 
-    public FeedController(FeedService feedService, FeedMapper feedMapper) {
+    public FeedController(FeedService feedService, FeedMapper feedMapper,
+                          FeedCommentService feedCommentService,
+                          FeedTagService feedTagService,
+                          FeedTagMapper feedTagMapper) {
         this.feedService = feedService;
         this.feedMapper = feedMapper;
+        this.feedCommentService = feedCommentService;
+        this.feedTagService = feedTagService;
+        this.feedTagMapper = feedTagMapper;
+    }
+
+    @PostMapping
+    public ResponseEntity postFeed (@RequestBody @Valid FeedPostDto feedPostDto) {
+        Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);
+        Feed createFeed = feedService.createFeed(feed, feedPostDto.getCatId());
+        List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());
+        List<FeedTag> createFeedTags = feedTagService.createTags(createFeed, feedTags);
+        return new ResponseEntity<>(feedMapper.feedToFeedResponseDto(createFeed), HttpStatus.CREATED);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
@@ -1,0 +1,18 @@
+package com.twentyfour_seven.catvillage.feed.dto;
+
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FeedPostDto {
+    private long catId;
+    private List<PictureDto> pictures;
+    private String body;
+    private List<FeedTagDto> tags;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedResponseDto.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.feed.dto;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,7 +15,14 @@ import java.util.List;
 public class FeedResponseDto {
     private long feedId;
     private long catId;
-    private List<String> picture;
+    private List<PictureDto> pictures;
     private String body;
-    private List<String> tag;
+    private List<FeedTagDto> tags;
+
+    public FeedResponseDto(long feedId, long catId, List<PictureDto> pictures, String body) {
+        this.feedId = feedId;
+        this.catId = catId;
+        this.pictures = pictures;
+        this.body = body;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedTagDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedTagDto.java
@@ -1,0 +1,17 @@
+package com.twentyfour_seven.catvillage.feed.dto;
+
+import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FeedTagDto {
+    private String tag;
+
+    public FeedTagDto (FeedTag feedTag) {
+        this.tag = feedTag.getTagName();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
@@ -3,6 +3,7 @@ package com.twentyfour_seven.catvillage.feed.entity;
 import com.fasterxml.jackson.annotation.JsonBackReference;
 import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.twentyfour_seven.catvillage.audit.DateTable;
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import lombok.Getter;
@@ -36,9 +37,9 @@ public class Feed extends DateTable {
 
     @Setter
     @ManyToOne
-    @JoinColumn(name = "USER_ID")
+    @JoinColumn(name = "CAT_ID")
     @JsonBackReference
-    private User user;
+    private Cat cat;
 
     @OneToMany(mappedBy = "feed", cascade = CascadeType.REMOVE)
     @JsonManagedReference

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -1,8 +1,42 @@
 package com.twentyfour_seven.catvillage.feed.mapper;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedResponseDto;
+import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface FeedMapper {
+    default FeedResponseDto feedToFeedResponseDto(Feed feed) {
+        if (feed == null) {
+            return null;
+        }
+        List<PictureDto> pictureDtos = new ArrayList<>();
+        feed.getPictures().forEach(
+                picture -> pictureDtos.add(new PictureDto(picture))
+        );
+        return new FeedResponseDto(
+                feed.getFeedId(),
+                feed.getCat().getCatId(),
+                pictureDtos,
+                feed.getBody()
+        );
+    }
+
+    default Feed feedPostDtoToFeed(FeedPostDto feedPostDto) {
+        if (feedPostDto == null) {
+            return null;
+        }
+        Feed feed = new Feed(feedPostDto.getBody());
+        feedPostDto.getPictures().forEach(
+                pictureDto -> feed.getPictures().add(Picture.builder().path(pictureDto.getPicture()).build())
+        );
+        return feed;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedTagMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedTagMapper.java
@@ -1,0 +1,30 @@
+package com.twentyfour_seven.catvillage.feed.mapper;
+
+import com.twentyfour_seven.catvillage.feed.dto.FeedTagDto;
+import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
+import com.twentyfour_seven.catvillage.feed.entity.TagToFeed;
+import org.mapstruct.Mapper;
+import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
+public interface FeedTagMapper {
+    default FeedTag tagToFeedToFeedTag (TagToFeed tagToFeed) {
+        if (tagToFeed == null) {
+            return null;
+        }
+        return new FeedTag(tagToFeed.getFeedTag().getTagName());
+    }
+
+    List<FeedTag> tagToFeedsToFeedTags (List<TagToFeed> tagToFeeds);
+
+    default FeedTag feedTagDtoToFeedTag (FeedTagDto feedTagDto) {
+        if (feedTagDto == null) {
+            return null;
+        }
+        return new FeedTag(feedTagDto.getTag());
+    }
+
+    List<FeedTag> feedTagDtosToFeedTags (List<FeedTagDto> feedTagDtos);
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -1,13 +1,33 @@
 package com.twentyfour_seven.catvillage.feed.service;
 
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
+import com.twentyfour_seven.catvillage.cat.service.CatService;
+import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
+import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.repository.FeedRepository;
 import org.springframework.stereotype.Service;
 
 @Service
 public class FeedService {
     private final FeedRepository feedRepository;
+    private final CatService catService;
+    private final PictureService pictureService;
 
-    public FeedService(FeedRepository feedRepository) {
+    public FeedService(FeedRepository feedRepository,
+                       CatService catService,
+                       PictureService pictureService) {
         this.feedRepository = feedRepository;
+        this.catService = catService;
+        this.pictureService = pictureService;
+    }
+
+    public Feed createFeed(Feed feed, long catId) {
+        Cat findCat = catService.findVerifiedCat(catId);
+        feed.setCat(findCat);
+        feed.getPictures().forEach(
+                picture -> pictureService.createPicture(picture)
+        );
+
+        return feedRepository.save(feed);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
@@ -1,8 +1,13 @@
 package com.twentyfour_seven.catvillage.feed.service;
 
+import com.twentyfour_seven.catvillage.feed.entity.Feed;
+import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
+import com.twentyfour_seven.catvillage.feed.entity.TagToFeed;
 import com.twentyfour_seven.catvillage.feed.repository.FeedTagRepository;
 import com.twentyfour_seven.catvillage.feed.repository.TagToFeedRepository;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
 
 @Service
 public class FeedTagService {
@@ -12,5 +17,21 @@ public class FeedTagService {
     public FeedTagService(FeedTagRepository feedTagRepository, TagToFeedRepository tagToFeedRepository) {
         this.feedTagRepository = feedTagRepository;
         this.tagToFeedRepository = tagToFeedRepository;
+    }
+
+    public List<FeedTag> createTags (Feed feed, List<FeedTag> feedTags) {
+        feedTags.forEach(feedTag -> {
+            FeedTag createFeedTag = createTag(feedTag);
+            createTagToFeed(new TagToFeed(feed, createFeedTag));
+        });
+        return feedTags;
+    }
+
+    public FeedTag createTag (FeedTag feedTag) {
+        return feedTagRepository.save(feedTag);
+    }
+
+    public TagToFeed createTagToFeed (TagToFeed tagToFeed) {
+        return tagToFeedRepository.save(tagToFeed);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -78,10 +78,6 @@ public class User extends DateTable {
     @JsonManagedReference
     private final List<Cat> cats = new ArrayList<>();
 
-    @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
-    @JsonManagedReference
-    private final List<Feed> feeds = new ArrayList<>();
-
     @JsonManagedReference
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE)
     private final List<FeedComment> feedComments = new ArrayList<>();


### PR DESCRIPTION
## 주요 변경 사항
- User <-> Feed 양방향 연관관계에서 Cat <-> Feed 연관관계로 수정
- pictureDto 작성
- feedController에 postFeed 메서드 작성

## 코드 변경 이유
- 냥이생활 피드에 글 작성은 고양이 프로필로만 가능하도록 정해져서 유저가 아닌 고양이 정보를 피드에서 가지고 있도록 하였습니다.
- picture는 응답과 요청에 정보가 포함되어 있기 때문에 path만 들어있는 dto를 작성하였습니다.
- 냥이생활 피드 작성에 필요한 클래스, 인터페이스 생성 및 로직 작성 했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- PictureDto
- FeedController
- FeedService
- FeedTagService

## 연결된 이슈
#137 

## 자료 (스크린샷 등)
