### PR TITLE
fix: style폴더 path-alias 오타 수정

### DIFF
--- a/client/tsconfig.json
+++ b/client/tsconfig.json
@@ -28,12 +28,11 @@
       "@pages/*": ["./src/pages/*"],
       "@Routes/*": ["./src/routes/*"],
       "@Stores/*": ["./src/stores/*"],
-      "@Style/*": ["./src/style/*"],
+      "@Styles/*": ["./src/styles/*"],
       "@Utils/*": ["./src/utils/*"],
-      "@/*": ["./src/*"],
+      "@/*": ["./src/*"]
     }
   },
   "include": ["src"],
   "typeRoots": ["./@types", "./node_modules/@types"]
 }
-


### PR DESCRIPTION
## 주요 변경 사항
src/components/styles에 대한 path-alias의 오타를 수정했습니다.

## 코드 변경 이유
오타 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
`"@Style/*": ["./src/style/*"],`
  `"@Styles/*": ["./src/styles/*"],`

## 연결된 이슈

## 자료 (스크린샷 등)
