### PR TITLE
feat: '고양이 등록하기' 기능 구현 및 '고양이 수정하기' 기능 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
@@ -1,13 +1,12 @@
 package com.twentyfour_seven.catvillage.cat.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.Setter;
+import lombok.*;
 
 import java.util.List;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class CatResponseDto {
     long catId;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatTagMapper.java
@@ -1,6 +1,5 @@
 package com.twentyfour_seven.catvillage.cat.mapper;
 
-import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.CatTag;
@@ -12,23 +11,33 @@ import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CatTagMapper {
-    default public CatTag tagPostDtoToCatTag(CatTagPostDto catTagPostDto) {
+    default CatTag tagPostDtoToCatTag(CatTagPostDto catTagPostDto) {
         if (catTagPostDto == null) return null;
         CatTag catTag = new CatTag(catTagPostDto.getTag());
         return catTag;
     }
-    public List<CatTag> catTagPostDtosToCatTags(List<CatTagPostDto> catTagPostDtos);
 
-    default public CatTagResponseDto catTagToCatTagResponseDto(CatTag catTag) {
+    List<CatTag> catTagPostDtosToCatTags(List<CatTagPostDto> catTagPostDtos);
+
+    default CatTagResponseDto catTagToCatTagResponseDto(CatTag catTag) {
         CatTagResponseDto catTagResponseDto = new CatTagResponseDto(catTag.getTagName());
         return catTagResponseDto;
     }
 
-    public List<CatTagResponseDto> catTagsToCatTagResponseDtos(List<CatTag> catTags);
+    List<CatTagResponseDto> catTagsToCatTagResponseDtos(List<CatTag> catTags);
 
-    default public CatTag tagToCatToCatTag(TagToCat tagToCat) {
+    default CatTag tagToCatToCatTag(TagToCat tagToCat) {
         return tagToCat.getCatTag();
     }
 
-    public List<CatTag> tagToCatsToCatTags(List<TagToCat> tagToCats);
+    List<CatTag> tagToCatsToCatTags(List<TagToCat> tagToCats);
+
+    default CatTagResponseDto tagToCatToCatTagResponseDto(TagToCat tagToCat) {
+        if (tagToCat == null) {
+            return null;
+        }
+        return catTagToCatTagResponseDto(tagToCatToCatTag(tagToCat));
+    }
+
+    List<CatTagResponseDto> tagToCatsToCatTagResponseDtos(List<TagToCat> tagToCats);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/TagToCatRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/repository/TagToCatRepository.java
@@ -1,8 +1,13 @@
 package com.twentyfour_seven.catvillage.cat.repository;
 
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
+import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.entity.TagToCat;
 import com.twentyfour_seven.catvillage.cat.entity.TagToCatId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface TagToCatRepository extends JpaRepository<TagToCat, TagToCatId> {
+    public Optional<TagToCat> findByCatTagAndCat (CatTag catTag, Cat cat);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -5,9 +5,11 @@ import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.repository.CatRepository;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
+import org.springframework.web.server.MethodNotAllowedException;
 
 import java.util.List;
 import java.util.Optional;
@@ -27,10 +29,12 @@ public class CatService {
         this.beanUtils = beanUtils;
     }
 
-    public Cat saveCat(Cat cat, String breed, List<CatTag> catTags) {
-        // TODO: user, breed(CatInfo) 정보 꺼내서 저장 필요
-        catTagService.saveTag(catTags, cat);
+    public Cat createCat(Cat cat, String breed, List<CatTag> catTags, String email) {
+        // TODO: breed(CatInfo) 정보 꺼내서 Cat 에 저장 필요
+        User findUser = userService.findVerifiedEmail(email);
+        cat.setUser(findUser);
         Cat createdCat = catRepository.save(cat);
+        catTagService.saveTag(catTags, createdCat);
         return createdCat;
     }
 
@@ -47,17 +51,20 @@ public class CatService {
 
     public void removeCat(long catId) {
         Cat findCat = findVerifiedCat(catId);
-//        catTagService.removeTagToCats(findCat.getTagToCats());
         catRepository.delete(findCat);
     }
 
-    public Cat updateCat(Cat cat, String breed, List<CatTag> catTags) {
+    public Cat updateCat(Cat cat, String breed, List<CatTag> catTags, String email) {
         Cat findCat = findVerifiedCat(cat.getCatId());
         // TODO:  CatInfo 구현 후 주석 제거 필요
 //        CatInfo findBreed = breedService.findByKorName(breed);
 //        cat.setBreed(findBreed);
-
+        // 요청을 보낸 User 가 등록한 User 와 동일한지 확인
+        if (findCat.getUser().getEmail() != email) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
         Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
+        catTagService.updateTag(catTags, updatingCat);
         return catRepository.save(updatingCat);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
@@ -5,6 +5,7 @@ import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.entity.TagToCat;
 import com.twentyfour_seven.catvillage.cat.repository.CatTagRepository;
 import com.twentyfour_seven.catvillage.cat.repository.TagToCatRepository;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,9 +16,13 @@ public class CatTagService {
     private final CatTagRepository catTagRepository;
     private final TagToCatRepository tagToCatRepository;
 
-    public CatTagService(CatTagRepository catTagRepository, TagToCatRepository tagToCatRepository) {
+    private final CustomBeanUtils beanUtils;
+
+    public CatTagService(CatTagRepository catTagRepository, TagToCatRepository tagToCatRepository,
+                         CustomBeanUtils beanUtils) {
         this.catTagRepository = catTagRepository;
         this.tagToCatRepository = tagToCatRepository;
+        this.beanUtils = beanUtils;
     }
 
     public List<CatTag> saveTag(List<CatTag> catTags, Cat cat) {
@@ -42,5 +47,23 @@ public class CatTagService {
 
     public void removeTagToCats(List<TagToCat> tagToCats) {
         tagToCatRepository.deleteAll(tagToCats);
+    }
+
+    public List<CatTag> updateTag (List<CatTag> catTags, Cat cat) {
+        catTags.forEach(
+                catTag -> {
+                    catTag = findExistCatTag(catTag);
+                    TagToCat tagToCat = new TagToCat(catTag, cat);
+                    findExistTagToCat(tagToCat);
+                }
+        );
+        return catTags;
+    }
+
+    public TagToCat findExistTagToCat (TagToCat tagToCat) {
+        Optional<TagToCat> optionalTagToCat =
+                tagToCatRepository.findByCatTagAndCat(tagToCat.getCatTag(), tagToCat.getCat());
+        TagToCat createTagToCat = optionalTagToCat.orElse(tagToCatRepository.save(tagToCat));
+        return createTagToCat;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -8,7 +8,8 @@ public enum ExceptionCode {
     MEMBER_NAME_EXISTS(409, "Name already in use"),
     BREED_NOT_FOUND(404, "Breed not found"),
     CAT_NOT_FOUND(409, "Cat not found"),
-    PICTURE_NOT_FOUND(409, "Picture not found");
+    PICTURE_NOT_FOUND(409, "Picture not found"),
+    INVALID_USER(405, "Method not allowed");
 
     @Getter
     private final int status;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
         return findUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
     }
 
-    private User findVerifiedEmail(String email) {
+    public User findVerifiedEmail(String email) {
         Optional<User> findUser = userRepository.findByEmail(email);
         return findUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
     }


### PR DESCRIPTION
## 주요 변경 사항
- CatController에 postCat 구현
- CatController에 patchCat 수정
- ExceptionCode에 INVALID_USER ("Method not allowed") 추가
- UserService의 findVerifiedEmail private에서 public으로 수정

## 코드 변경 이유
- 고양이 등록하기 시 로그인 된 유저 정보를 principal에서 가져와서 유저를 찾은 다음 cat에 같이 저장합니다.
- 고양이 수정하기 시 로그인 된 유저 정보와 처음에 고양이를 등록했던 유저 정보가 일치하지 않을 시 ExceptionCode.INVALID_USER 를 사용하여 예외 처리합니다.
- UserService의 findVerifiedEmail 은 다른 엔티티에서 로그인된 유저 정보(principal)에서 username(email 사용)로 유저의 정보를 불러와야 하기 때문에 public으로 변경합니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatService의 saveCat과 updateCat 부분
- tag가 올바르게 저장되는지
- 로그인된 유저 정보를 올바르게 사용하는지
- ExceptionCode

## 연결된 이슈
#62 

## 자료 (스크린샷 등)
