### PR TITLE
Feat/create board

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,16 +1,24 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
-import com.twentyfour_seven.catvillage.board.entity.BoardComment;
+import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
+import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
 import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
-import com.twentyfour_seven.catvillage.board.service.BoardTagService;
-import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.service.UserService;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.transaction.Transactional;
+import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/집사생활")
@@ -19,13 +27,30 @@ import javax.transaction.Transactional;
 public class BoardController {
     private BoardMapper boardMapper;
     private BoardService boardService;
+    private UserService userService;
     private BoardCommentService boardCommentService;
-    private BoardTagService boardTagService;
 
-    public BoardController(BoardMapper boardMapper, BoardService boardService, BoardCommentService boardCommentService, BoardTagService boardTagService) {
+    public BoardController(BoardMapper boardMapper, BoardService boardService, UserService userService, BoardCommentService boardCommentService) {
         this.boardMapper = boardMapper;
         this.boardService = boardService;
+        this.userService = userService;
         this.boardCommentService = boardCommentService;
-        this.boardTagService = boardTagService;
+    }
+
+    @PostMapping
+    public ResponseEntity postBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
+                                    @Valid @RequestBody BoardPostDto requestBody) {
+        // 집사생활의 태그는 제공되는 태그 중 선택하여 등록하는 태그이기 때문에 아래와 같은 로직은 불필요
+//        List<BoardTag> boardTags = boardTagService.registerBoardTags(requestBody.getTag());
+        Board board = boardMapper.boardPostDtoToBoard(requestBody);
+
+        // 작성자 정보 획득
+        User findUser = userService.findVerifiedEmail(user.getUsername());
+        board.setUser(findUser);
+
+        Board createdBoard = boardService.createBoard(board, requestBody.getTag(), requestBody.getPicture());
+        return new ResponseEntity<>(
+                boardMapper.boardToBoardPostResponseDto(createdBoard),
+                HttpStatus.CREATED);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
@@ -1,11 +1,13 @@
 package com.twentyfour_seven.catvillage.board.dto;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -13,8 +15,8 @@ import java.util.ArrayList;
 public class BoardPostDto {
     private String title;
     private String body;
-    private ArrayList<String> tag = new ArrayList<>();
-    private ArrayList<String> picture = new ArrayList<>();
+    private List<BoardTagDto> tag = new ArrayList<>();
+    private List<PictureDto> picture = new ArrayList<>();
 
     @Builder
     public BoardPostDto(String title, String body) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostResponseDto.java
@@ -1,11 +1,13 @@
 package com.twentyfour_seven.catvillage.board.dto;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @Setter
@@ -14,8 +16,8 @@ public class BoardPostResponseDto {
     private Long boardId;
     private String title;
     private String body;
-    private ArrayList<String> tag = new ArrayList<>();
-    private ArrayList<String> picture = new ArrayList<>();
+    private List<BoardTagDto> tag = new ArrayList<>();
+    private List<PictureDto> picture = new ArrayList<>();
 
     @Builder
     public BoardPostResponseDto(Long boardId, String title, String body) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardTagDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardTagDto.java
@@ -1,0 +1,17 @@
+package com.twentyfour_seven.catvillage.board.dto;
+
+import com.twentyfour_seven.catvillage.board.entity.BoardTag;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardTagDto {
+    private String tag;
+
+    public BoardTagDto(BoardTag boardTag) {
+        this.tag = boardTag.getTagName();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -2,7 +2,9 @@ package com.twentyfour_seven.catvillage.board.mapper;
 
 import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
+import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
@@ -29,11 +31,11 @@ public interface BoardMapper {
                     .build();
             // Tag name 등록
             board.getTagToBoards().forEach(e -> {
-                response.getTag().add(e.getBoardTag().getTagName());
+                response.getTag().add(new BoardTagDto(e.getBoardTag()));
             });
             // Picture path 등록
             board.getPictures().forEach(e -> {
-                response.getPicture().add(e.getPath());
+                response.getPicture().add(new PictureDto(e));
             });
             return response;
         }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -1,7 +1,41 @@
 package com.twentyfour_seven.catvillage.board.mapper;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
+import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
+import com.twentyfour_seven.catvillage.board.entity.Board;
 import org.mapstruct.Mapper;
 
 @Mapper(componentModel = "spring")
 public interface BoardMapper {
+    default Board boardPostDtoToBoard(BoardPostDto requestBody) {
+        if(requestBody == null) {
+            return null;
+        } else {
+            return Board.builder()
+                .title(requestBody.getTitle())
+                .body(requestBody.getBody())
+                .build();
+        }
+    }
+
+    default BoardPostResponseDto boardToBoardPostResponseDto(Board board) {
+        if(board == null) {
+            return null;
+        } else {
+            BoardPostResponseDto response = BoardPostResponseDto.builder()
+                    .boardId(board.getBoardId())
+                    .title(board.getTitle())
+                    .body(board.getBody())
+                    .build();
+            // Tag name 등록
+            board.getTagToBoards().forEach(e -> {
+                response.getTag().add(e.getBoardTag().getTagName());
+            });
+            // Picture path 등록
+            board.getPictures().forEach(e -> {
+                response.getPicture().add(e.getPath());
+            });
+            return response;
+        }
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardTagRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardTagRepository.java
@@ -3,5 +3,8 @@ package com.twentyfour_seven.catvillage.board.repository;
 import com.twentyfour_seven.catvillage.board.entity.BoardTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface BoardTagRepository extends JpaRepository<BoardTag, Long> {
+    Optional<BoardTag> findByTagName(String tagName);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/TagToBoardRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/TagToBoardRepository.java
@@ -1,8 +1,14 @@
 package com.twentyfour_seven.catvillage.board.repository;
 
+import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.board.entity.BoardTag;
 import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
 import com.twentyfour_seven.catvillage.board.entity.TagToBoardId;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 public interface TagToBoardRepository extends JpaRepository<TagToBoard, TagToBoardId> {
+    Optional<TagToBoard> findByBoardTag(BoardTag boardTag);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -1,17 +1,57 @@
 package com.twentyfour_seven.catvillage.board.service;
 
 import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
 import com.twentyfour_seven.catvillage.board.repository.BoardRepository;
+import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class BoardService {
     private BoardRepository boardRepository;
+    private TagToBoardService tagToBoardService;
+    private PictureService pictureService;
     private CustomBeanUtils<Board> beanUtils;
 
-    public BoardService(BoardRepository boardRepository, CustomBeanUtils<Board> beanUtils) {
+    public BoardService(BoardRepository boardRepository, TagToBoardService tagToBoardService, PictureService pictureService, CustomBeanUtils<Board> beanUtils) {
         this.boardRepository = boardRepository;
+        this.tagToBoardService = tagToBoardService;
+        this.pictureService = pictureService;
         this.beanUtils = beanUtils;
+    }
+
+    public Board createBoard(Board board, List<String> tags, List<String> pictures) {
+        // ID를 얻기 위한 저장 로직
+        Board createdBoard = boardRepository.save(board);
+
+        // TagToBoard 리스트를 생성하여 DB에 저장 및 반환
+        List<TagToBoard> tagToBoard = tagToBoardService.createTagToBoard(createdBoard, tags);
+        // createdBoard 객체의 TagToBoard 필드에 추가
+        createdBoard.getTagToBoards().addAll(tagToBoard);
+
+        // Picture 리스트를 생성하여 DB에 저장 및 반환
+        List<Picture> pictureList = pictures.stream().map(e ->
+                pictureService.createPicture(Picture.builder()
+                        .board(createdBoard)
+                        .path(e)
+                        .build())
+        ).collect(Collectors.toList());
+        createdBoard.getPictures().addAll(pictureList);
+
+        return createdBoard;
+    }
+
+    private Board findVerifiedBoard(Long boardId) {
+        Optional<Board> findBoard = boardRepository.findById(boardId);
+        return findBoard.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOARD_NOT_FOUND));
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -1,9 +1,11 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
 import com.twentyfour_seven.catvillage.board.repository.BoardRepository;
 import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
@@ -29,7 +31,7 @@ public class BoardService {
         this.beanUtils = beanUtils;
     }
 
-    public Board createBoard(Board board, List<String> tags, List<String> pictures) {
+    public Board createBoard(Board board, List<BoardTagDto> tags, List<PictureDto> pictures) {
         // ID를 얻기 위한 저장 로직
         Board createdBoard = boardRepository.save(board);
 
@@ -42,7 +44,7 @@ public class BoardService {
         List<Picture> pictureList = pictures.stream().map(e ->
                 pictureService.createPicture(Picture.builder()
                         .board(createdBoard)
-                        .path(e)
+                        .path(e.getPicture())
                         .build())
         ).collect(Collectors.toList());
         createdBoard.getPictures().addAll(pictureList);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
 import com.twentyfour_seven.catvillage.board.entity.BoardTag;
 import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
@@ -31,8 +32,8 @@ public class BoardTagService {
 //        }).collect(Collectors.toList());
 //    }
 
-    public List<BoardTag> getBoardTags(List<String> boardTags) {
-        return boardTags.stream().map(this::findVerifiedTagName)
+    public List<BoardTag> getBoardTags(List<BoardTagDto> boardTags) {
+        return boardTags.stream().map(e -> findVerifiedTagName(e.getTag()))
                 .collect(Collectors.toList());
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardTagService.java
@@ -1,7 +1,15 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.entity.BoardTag;
 import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class BoardTagService {
@@ -9,5 +17,34 @@ public class BoardTagService {
 
     public BoardTagService(BoardTagRepository boardTagRepository) {
         this.boardTagRepository = boardTagRepository;
+    }
+
+    // 집사생활의 태그는 제공되는 태그 중 선택하여 등록하는 태그이기 때문에 아래와 같은 로직은 불필요
+//    public List<BoardTag> registerBoardTags(ArrayList<String> boardTags) {
+//        return boardTags.stream().map(e -> {
+//            BoardTag boardTag = findVerifiedTagName(e);
+//            if(boardTag.getBoardTagId() == null) {
+//                return boardTagRepository.save(boardTag);
+//            } else {
+//                return boardTag;
+//            }
+//        }).collect(Collectors.toList());
+//    }
+
+    public List<BoardTag> getBoardTags(List<String> boardTags) {
+        return boardTags.stream().map(this::findVerifiedTagName)
+                .collect(Collectors.toList());
+    }
+
+    private BoardTag findVerifiedBoardTag(Long boardId) {
+        Optional<BoardTag> findBoard = boardTagRepository.findById(boardId);
+        return findBoard.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOARD_TAG_NOT_FOUND));
+    }
+
+    private BoardTag findVerifiedTagName(String tagName) {
+        Optional<BoardTag> findBoard = boardTagRepository.findByTagName(tagName);
+        return findBoard.orElseThrow(() -> new BusinessLogicException(ExceptionCode.BOARD_TAG_NOT_FOUND));
+        // 집사생활의 태그는 제공되는 태그 중 선택하여 등록하는 태그이기 때문에 아래와 같은 로직은 불필요
+//        return findBoard.orElse(BoardTag.builder().tagName(tagName).build());
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.entity.BoardTag;
 import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
@@ -25,7 +26,7 @@ public class TagToBoardService {
         this.boardTagService = boardTagService;
     }
 
-    public List<TagToBoard> createTagToBoard(Board board, List<String> tags) {
+    public List<TagToBoard> createTagToBoard(Board board, List<BoardTagDto> tags) {
         List<BoardTag> boardTags = boardTagService.getBoardTags(tags);
         return boardTags.stream().map(e -> {
                     TagToBoard tagToBoard = TagToBoard.builder()

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
@@ -1,13 +1,39 @@
 package com.twentyfour_seven.catvillage.board.service;
 
+import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.board.entity.BoardTag;
+import com.twentyfour_seven.catvillage.board.entity.TagToBoard;
+import com.twentyfour_seven.catvillage.board.entity.TagToBoardId;
+import com.twentyfour_seven.catvillage.board.repository.BoardTagRepository;
 import com.twentyfour_seven.catvillage.board.repository.TagToBoardRepository;
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
 
 @Service
 public class TagToBoardService {
-    private TagToBoardRepository tagToBoardRepository;
 
-    public TagToBoardService(TagToBoardRepository tagToBoardRepository) {
+    private TagToBoardRepository tagToBoardRepository;
+    private BoardTagService boardTagService;
+
+    public TagToBoardService(TagToBoardRepository tagToBoardRepository, BoardTagService boardTagService) {
         this.tagToBoardRepository = tagToBoardRepository;
+        this.boardTagService = boardTagService;
+    }
+
+    public List<TagToBoard> createTagToBoard(Board board, List<String> tags) {
+        List<BoardTag> boardTags = boardTagService.getBoardTags(tags);
+        return boardTags.stream().map(e -> {
+                    TagToBoard tagToBoard = TagToBoard.builder()
+                            .board(board)
+                            .boardTag(e)
+                            .build();
+                    return tagToBoardRepository.save(tagToBoard);
+                }
+        ).collect(Collectors.toList());
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
@@ -1,0 +1,17 @@
+package com.twentyfour_seven.catvillage.common.picture.dto;
+
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class PictureDto {
+    private String picture;
+
+    public PictureDto(Picture picture) {
+        this.picture = picture.getPath();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
@@ -33,8 +33,11 @@ public class Picture {
     private String path;
 
     @Builder
-    public Picture(Long pictureId, String path) {
+
+    public Picture(Long pictureId, Feed feed, Board board, String path) {
         this.pictureId = pictureId;
+        this.feed = feed;
+        this.board = board;
         this.path = path;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -8,7 +8,9 @@ public enum ExceptionCode {
     MEMBER_NAME_EXISTS(409, "Name already in use"),
     BREED_NOT_FOUND(404, "Breed not found"),
     CAT_NOT_FOUND(409, "Cat not found"),
-    PICTURE_NOT_FOUND(409, "Picture not found");
+    PICTURE_NOT_FOUND(409, "Picture not found"),
+    BOARD_NOT_FOUND(409, "Board not found"),
+    BOARD_TAG_NOT_FOUND(409, "Board tag not found");
 
     @Getter
     private final int status;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -59,7 +59,7 @@ public class UserService {
         return findUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
     }
 
-    private User findVerifiedEmail(String email) {
+    public User findVerifiedEmail(String email) {
         Optional<User> findUser = userRepository.findByEmail(email);
         return findUser.orElseThrow(() -> new BusinessLogicException(ExceptionCode.MEMBER_NOT_FOUND));
     }


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활에 게시글을 등록하는 API 및 로직 구현
- 로그인 유저 정보를 사용하여 작성자 등록
- Picture entity 생성자에 feed, board 추가
- 예외 코드에 Picture, Board, Board tag not found 추가
- BoardPostDto 및 BoardPostResponseDto의 필드 중 picture 및 tag의 타입을 ArrayList -> List로 변경

## 코드 변경 이유
- 집사생활 게시글 등록을 위한 로직 추가
- 집사생활 게시글의 태그의 경우 제공되는 태그 중 선택하여 작성하는 방식이므로 입력 받은 태그가 존재하는지 확인 후 존재하는 경우에만 게시글이 저장되도록 구현, 존재하지 않는 태그가 들어오면 예외 발생
- Picture entity 생성자에 feed, board가 누락되어 해당 정보를 저장할 수 없기에 추가
- Dto의 picture 및 tag 타입을 확장성을 생각하여 ArrayList에서 List로 변경

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardController class
- BoarderMapper interface
- BoarderService class
- BoarderTagService class
- TagToBoarderService class

## 연결된 이슈
solved #107

## 자료 (스크린샷 등)
