### PR TITLE
feat: 집사생활 게시글 수정 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
@@ -11,13 +12,11 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import javax.transaction.Transactional;
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @RestController
@@ -52,5 +51,18 @@ public class BoardController {
         return new ResponseEntity<>(
                 boardMapper.boardToBoardPostResponseDto(createdBoard),
                 HttpStatus.CREATED);
+    }
+
+    @PatchMapping("/{boards-id}")
+    public ResponseEntity patchBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
+                                     @Positive @PathVariable("boards-id") Long boardId,
+                                     @Valid @RequestBody BoardPatchDto requestBody) {
+        Board board = boardMapper.boardPatchDtoToBoard(requestBody);
+        User findUser = userService.findVerifiedEmail(user.getUsername());
+        board.setUser(findUser);
+        Board updateBoard = boardService.updateBoard(board, requestBody.getTag(), requestBody.getPicture());
+        return new ResponseEntity<>(
+                boardMapper.boardToBoardPostResponseDto(updateBoard),
+                HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
@@ -1,10 +1,7 @@
 package com.twentyfour_seven.catvillage.board.dto;
 
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 import org.hibernate.validator.constraints.Length;
 
 import java.util.ArrayList;
@@ -13,7 +10,8 @@ import java.util.List;
 @Getter
 @Setter
 @NoArgsConstructor
-public class BoardPostDto {
+public class BoardPatchDto {
+    private Long boardId;
     @Length(max = 64)
     private String title;
     @Length(max = 1000)
@@ -22,7 +20,8 @@ public class BoardPostDto {
     private List<PictureDto> picture = new ArrayList<>();
 
     @Builder
-    public BoardPostDto(String title, String body) {
+    public BoardPatchDto(Long boardId, String title, String body) {
+        this.boardId = boardId;
         this.title = title;
         this.body = body;
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.board.mapper;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
@@ -38,6 +39,18 @@ public interface BoardMapper {
                 response.getPicture().add(new PictureDto(e));
             });
             return response;
+        }
+    }
+
+    default Board boardPatchDtoToBoard(BoardPatchDto requestBody) {
+        if(requestBody == null) {
+            return null;
+        } else {
+            return Board.builder()
+                    .boardId(requestBody.getBoardId())
+                    .title(requestBody.getTitle())
+                    .body(requestBody.getBody())
+                    .build();
         }
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/TagToBoardService.java
@@ -18,8 +18,8 @@ import java.util.stream.Collectors;
 @Service
 public class TagToBoardService {
 
-    private TagToBoardRepository tagToBoardRepository;
-    private BoardTagService boardTagService;
+    private final TagToBoardRepository tagToBoardRepository;
+    private final BoardTagService boardTagService;
 
     public TagToBoardService(TagToBoardRepository tagToBoardRepository, BoardTagService boardTagService) {
         this.tagToBoardRepository = tagToBoardRepository;
@@ -29,12 +29,31 @@ public class TagToBoardService {
     public List<TagToBoard> createTagToBoard(Board board, List<BoardTagDto> tags) {
         List<BoardTag> boardTags = boardTagService.getBoardTags(tags);
         return boardTags.stream().map(e -> {
-                    TagToBoard tagToBoard = TagToBoard.builder()
-                            .board(board)
-                            .boardTag(e)
-                            .build();
-                    return tagToBoardRepository.save(tagToBoard);
-                }
-        ).collect(Collectors.toList());
+            TagToBoard tagToBoard = TagToBoard.builder()
+                    .board(board)
+                    .boardTag(e)
+                    .build();
+            return tagToBoardRepository.save(tagToBoard);
+        }).collect(Collectors.toList());
+    }
+
+    public void deleteTagToBoard(TagToBoard tag) {
+        tagToBoardRepository.delete(tag);
+    }
+
+    public List<TagToBoard> updateTagToBoard(Board board, List<BoardTagDto> tags) {
+        List<BoardTag> boardTags = boardTagService.getBoardTags(tags);
+
+        // 기존에 존재하는 태그는 리스트에서 제거
+        board.getTagToBoards().forEach(e -> boardTags.remove(e.getBoardTag()));
+
+        // 추가된 태그만 저장 후 반환
+        return boardTags.stream().map(e -> {
+            TagToBoard tagToBoard = TagToBoard.builder()
+                    .board(board)
+                    .boardTag(e)
+                    .build();
+            return tagToBoardRepository.save(tagToBoard);
+        }).collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활에 등록된 게시글을 수정하는 API 및 로직 구현
- 게시글 작성자와 수정 요청한 유저 정보가 다른 경우 예외 처리
- 유효성 검증 추가
- Patch의 반환 데이터는 Post의 반환 데이터를 그대로 사용하기에 동일한 Mapper method 사용으로 구현

## 코드 변경 이유
- 집사생활에 등록된 게시글 수정을 위한 로직 추가
- 집사생활 게시글 등록 및 수정 데이터의 Title, Body 필드에 유효성 검증을 위한 어노테이션 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardController class
- BoardPatchDto class
- BoardService class
- TagToBoardService class

## 연결된 이슈
resolved #108

## 자료 (스크린샷 등)
