### PR TITLE
feat: Swagger API 명세에 들어갈 설명 코드 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -8,6 +8,7 @@ import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,6 +37,8 @@ public class BoardController {
         this.boardCommentService = boardCommentService;
     }
 
+    @Operation(summary = "집사생활 새 글 작성하기",
+            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다.")
     @PostMapping
     public ResponseEntity postBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                     @Valid @RequestBody BoardPostDto requestBody) {
@@ -53,6 +56,8 @@ public class BoardController {
                 HttpStatus.CREATED);
     }
 
+    @Operation(summary = "집사생활 글 수정하기",
+            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다. 처음에 글을 작성했던 유저와 로그인 되어 있는 유저가 다를 경우 405 에러가 납니다.")
     @PatchMapping("/{boards-id}")
     public ResponseEntity patchBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                      @Positive @PathVariable("boards-id") Long boardId,

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -8,6 +8,7 @@ import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -36,6 +37,8 @@ public class CatController {
         this.catTagMapper = catTagMapper;
     }
 
+    @Operation(summary = "고양이 등록하기",
+            description = "로그인한 유저 정보를 꺼내와서 유저에 고양이를 추가합니다. 만약 등록되지 않은 유저일 경우 404 에러가 납니다.")
     @PostMapping
     public ResponseEntity postCat(@Valid @RequestBody CatPostDto catPostDto,
                                   @AuthenticationPrincipal User user) {
@@ -48,6 +51,8 @@ public class CatController {
         return new ResponseEntity<>(catResponseDto, HttpStatus.CREATED);
     }
 
+    @Operation(summary = "고양이 프로필 정보 불러오기",
+            description = "로그인 하지 않은 유저도 요청 가능합니다." )
     @GetMapping("/{cats-id}")
     public ResponseEntity getCat(@PathVariable("cats-id") @Positive long catId) {
         Cat cat = catService.findCat(catId);
@@ -58,6 +63,8 @@ public class CatController {
         return new ResponseEntity<>(catResponseDto, HttpStatus.OK);
     }
 
+    @Operation(summary = "고양이 프로필 수정하기",
+            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.")
     @PatchMapping("/{cats-id}")
     public ResponseEntity patchCat(@PathVariable("cats-id") @Positive long catId,
                                    @Valid @RequestBody CatPostDto catPostDto,
@@ -69,6 +76,8 @@ public class CatController {
         return new ResponseEntity<>(catMapper.catToCatResponseDto(saveCat), HttpStatus.OK);
     }
 
+    @Operation(summary = "고양이 프로필 삭제하기",
+            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.")
     @DeleteMapping("/{cats-id}")
     public ResponseEntity deleteCat(@PathVariable("cats-id") @Positive long catId) {
         catService.removeCat(catId);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -4,10 +4,12 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
+import springfox.documentation.builders.ApiInfoBuilder;
 import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
 import springfox.documentation.schema.ModelRef;
+import springfox.documentation.service.ApiInfo;
 import springfox.documentation.service.Parameter;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
@@ -35,9 +37,18 @@ public class SwaggerConfig {
 
         return new Docket(DocumentationType.SWAGGER_2)
                 .useDefaultResponseMessages(true)
+                .apiInfo(apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.any())
                 .paths(PathSelectors.any())
+                .build();
+    }
+
+    private ApiInfo apiInfo() {
+        return new ApiInfoBuilder()
+                .title("냥빌리지 API 명세 페이지")
+                .description("냥빌리지 Swagger API 명세 페이지입니다.")
+                .version("1.0")
                 .build();
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -8,6 +8,7 @@ import com.twentyfour_seven.catvillage.feed.mapper.FeedTagMapper;
 import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +43,7 @@ public class FeedController {
         this.feedTagMapper = feedTagMapper;
     }
 
+    @Operation(summary = "냥이생활 피드 작성하기")
     @PostMapping
     public ResponseEntity postFeed (@RequestBody @Valid FeedPostDto feedPostDto) {
         Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
@@ -6,6 +6,7 @@ import com.twentyfour_seven.catvillage.security.dto.TokenRequestDto;
 import com.twentyfour_seven.catvillage.security.dto.UserRequestDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostResponseDto;
+import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -22,16 +23,21 @@ import javax.transaction.Transactional;
 public class AuthController {
     private final AuthService authService;
 
+    @Operation(summary = "회원가입", description = "이미 가입되어 있는 이메일일 경우 에러가 납니다.")
     @PostMapping("/signup")
     public ResponseEntity signup(@RequestBody UserPostDto userPostDto) {
         return new ResponseEntity<>(authService.signup(userPostDto), HttpStatus.CREATED);
     }
 
+    @Operation(summary = "로그인",
+            description = "등록되어 있지 않은 유저일 경우 에러가 납니다.")
     @PostMapping("/login")
     public ResponseEntity login(@RequestBody UserRequestDto userRequestDto) {
         return new ResponseEntity<>(authService.login(userRequestDto), HttpStatus.OK);
     }
 
+    @Operation(summary = "JWT 토큰 재발급",
+            description = "엑세스 토큰의 기간이 만료된 경우 해당 요청으로 엑세스 토큰 + 리프레시 토큰을 새로 발급받을 수 있습니다.")
     @PostMapping("/reissue")
     public ResponseEntity reissue(@RequestBody TokenRequestDto tokenRequestDto) {
         return new ResponseEntity<>(authService.reissue(tokenRequestDto), HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -6,6 +6,7 @@ import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.mapper.UserMapper;
 import com.twentyfour_seven.catvillage.user.service.UserService;
+import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -36,12 +37,16 @@ public class UserController {
 ////        return new ResponseEntity<>(userMapper.userToUserPostResponseDto(createUser), HttpStatus.CREATED);
 //    }
 
+    @Operation(summary = "유저 이름(displayName) 중복 검사",
+            description = "이미 등록되어 있는 이름일 경우 409 에러가 납니다.")
     @GetMapping("/names")
     public ResponseEntity getNameCheck(@RequestParam String name) {
         userService.nameDuplicateCheck(name);
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @Operation(summary = "유저 정보 가져오기(pagination)",
+            description = "등록되어 있는 모든 유저 정보를 페이지화하여 반환합니다. 로그인되지 않은 사용자도 요청 가능합니다.")
     @GetMapping
     public ResponseEntity getUsers(@RequestParam @Positive int page,
                                    @RequestParam @Positive int size) {
@@ -56,12 +61,16 @@ public class UserController {
         );
     }
 
+    @Operation(summary = "유저 정보 불러오기",
+            description = "로그인되지 않은 사용자도 요청 가능합니다.")
     @GetMapping("/{user-id}")
     public ResponseEntity getUser(@PathVariable("user-id") Long userId) {
         User findUser = userService.findUser(userId);
         return new ResponseEntity<>(userMapper.userToUserGetResponseDto(findUser), HttpStatus.OK);
     }
 
+    @Operation(summary = "유저 정보 변경",
+            description = "로그인된 유저가 정보를 변경하려는 유저와 다른 경우 405 에러가 납니다.")
     @PatchMapping("/{user-id}")
     public ResponseEntity patchUser(@PathVariable("user-id") Long userId,
                                     @Valid @RequestBody UserPatchDto requestBody) {
@@ -70,6 +79,8 @@ public class UserController {
         return new ResponseEntity<>(userMapper.userToUserPatchResponseDto(updateUser), HttpStatus.OK);
     }
 
+    @Operation(summary = "유저 탈퇴",
+            description = "유저 정보가 바로 삭제되지 않고 7일동안 유지된 후 삭제됩니다. 그 이전에는 복구 가능합니다.")
     @DeleteMapping("/{user-id}/delete") // TODO : Security 적용 이후 "/delete"로 경로 변경 의논 필요
     public ResponseEntity deleteUser(@PathVariable("user-id") Long userId) {
         userService.removeUser(userId);


### PR DESCRIPTION
## 주요 변경 사항
- 작성된 모든 controller에 summary, description 추가

## 코드 변경 이유
- 기존 Swagger API 명세는 요청 별 설명이 써져있지 않아 읽기 불편하여 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- 모든 controller
- SwaggerConfig

## 연결된 이슈

## 자료 (스크린샷 등)
