### PR TITLE
feat: 집사생활 게시글 삭제 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -70,4 +70,15 @@ public class BoardController {
                 boardMapper.boardToBoardPostResponseDto(updateBoard),
                 HttpStatus.OK);
     }
+
+    @Operation(summary = "집사생활 글 삭제하기",
+    description = "존재하지 않는 글의 식별자가 들어올 경우 에러가 납니다. 글 작성자가 아닌 다른 유저가 제거를 요청하면 405 에러가 납니다.")
+    @DeleteMapping("/{board-id}")
+    public ResponseEntity deleteBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
+                                      @Positive @PathVariable("board-id") Long boardId)
+    {
+        User findUser = userService.findVerifiedEmail(user.getUsername());
+        boardService.deleteBoard(findUser, boardId);
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -7,6 +7,7 @@ import com.twentyfour_seven.catvillage.board.repository.BoardRepository;
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
+import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
@@ -89,6 +90,14 @@ public class BoardService {
         findBoard.getPictures().addAll(pictureList);
 
         return boardRepository.save(findBoard);
+    }
+
+    public void deleteBoard(User user, Long boardId) {
+        Board findBoard = findVerifiedBoard(boardId);
+        if(!findBoard.getUser().equals(user)) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+        boardRepository.delete(findBoard);
     }
 
     private Board findVerifiedBoard(Long boardId) {


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활에 등록된 게시글을 삭제하는 기능 구현
- 작성자와 동일한 유저만 삭제가 가능하도록 구현

## 코드 변경 이유
- 집사생활에 등록된 게시글을 작성자가 삭제할 수 있는 로직 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardController class
- BoardService class

## 연결된 이슈
resolved #109

## 자료 (스크린샷 등)
