### PR TITLE
fix: 집사생활 등록 및 수정시 사용되는 DTO 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
@@ -16,13 +16,15 @@ public class BoardPatchDto {
     private String title;
     @Length(max = 1000)
     private String body;
-    private List<BoardTagDto> tag = new ArrayList<>();
-    private List<PictureDto> picture = new ArrayList<>();
+    private List<BoardTagDto> tag;
+    private List<PictureDto> picture;
 
     @Builder
-    public BoardPatchDto(Long boardId, String title, String body) {
+    public BoardPatchDto(Long boardId, String title, String body, List<BoardTagDto> tag, List<PictureDto> picture) {
         this.boardId = boardId;
         this.title = title;
         this.body = body;
+        this.tag = tag;
+        this.picture = picture;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
@@ -18,12 +18,14 @@ public class BoardPostDto {
     private String title;
     @Length(max = 1000)
     private String body;
-    private List<BoardTagDto> tag = new ArrayList<>();
-    private List<PictureDto> picture = new ArrayList<>();
+    private List<BoardTagDto> tag;
+    private List<PictureDto> picture;
 
     @Builder
-    public BoardPostDto(String title, String body) {
+    public BoardPostDto(String title, String body, List<BoardTagDto> tag, List<PictureDto> picture) {
         this.title = title;
         this.body = body;
+        this.tag = tag;
+        this.picture = picture;
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- List 필드들에 new ArrayList<>()를 바로 대입하던 코드 제거
- List 필드들이 생성자에서 누락되어 있던 부분 수정

## 코드 변경 이유
- 입력을 받는데 사용되는 DTO 클래스에 초기화 코드는 필요 없으므로 제거
- 생성자에 필드가 빠져있어 대입할 수 없는 문제가 발생할 수 있으므로 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- 각각의 DTO 클래스의 List 필드들의 수정 부분

## 연결된 이슈

## 자료 (스크린샷 등)
