### PR TITLE
feat: 집사생활 전체 및 특정 게시글 보기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,9 +1,11 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardGetResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardMultiGetResponse;
 import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
+import com.twentyfour_seven.catvillage.board.mapper.BoardCommentMapper;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
 import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
@@ -28,12 +30,14 @@ import javax.validation.constraints.Positive;
 @Validated
 public class BoardController {
     private BoardMapper boardMapper;
+    private BoardCommentMapper boardCommentMapper;
     private BoardService boardService;
     private UserService userService;
     private BoardCommentService boardCommentService;
 
-    public BoardController(BoardMapper boardMapper, BoardService boardService, UserService userService, BoardCommentService boardCommentService) {
+    public BoardController(BoardMapper boardMapper, BoardCommentMapper boardCommentMapper, BoardService boardService, UserService userService, BoardCommentService boardCommentService) {
         this.boardMapper = boardMapper;
+        this.boardCommentMapper = boardCommentMapper;
         this.boardService = boardService;
         this.userService = userService;
         this.boardCommentService = boardCommentService;
@@ -56,7 +60,9 @@ public class BoardController {
     @GetMapping("/{boards-id}")
     public ResponseEntity getBoard(@Positive @PathVariable("boards-id") Long boardId) {
         Board board = boardService.findBoard(boardId);
-        return new ResponseEntity<>(boardMapper.boardToBoardGetResponseDto(board), HttpStatus.OK);
+        BoardGetResponseDto responseDto = boardMapper.boardToBoardGetResponseDto(board);
+        responseDto.setComments(boardCommentMapper.boardCommentsToBoardUserCommentResponseDtos(board.getBoardComments()));
+        return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
     @Operation(summary = "집사생활 새 글 작성하기",

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,14 +1,17 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
+import com.twentyfour_seven.catvillage.board.dto.BoardMultiGetResponse;
 import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
 import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
 import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
+import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -18,7 +21,6 @@ import org.springframework.web.bind.annotation.*;
 import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
-import java.util.List;
 
 @RestController
 @RequestMapping("/집사생활")
@@ -35,6 +37,26 @@ public class BoardController {
         this.boardService = boardService;
         this.userService = userService;
         this.boardCommentService = boardCommentService;
+    }
+
+    @Operation(summary = "집사생활 전체 게시글 보기")
+    @GetMapping
+    public ResponseEntity getBoards(@RequestParam @Positive int page,
+                                     @RequestParam @Positive int size) {
+        Page<Board> boards = boardService.findBoards(page - 1, size);
+        return new ResponseEntity<>(
+                new MultiResponseDto<BoardMultiGetResponse>(
+                        boardMapper.boardsToBoardMultiGetResponseDtos(boards.getContent()),
+                        boards
+                ),
+                HttpStatus.OK);
+    }
+
+    @Operation(summary = "집사생활 특정 게시글 보기")
+    @GetMapping("/{boards-id}")
+    public ResponseEntity getBoard(@Positive @PathVariable("boards-id") Long boardId) {
+        Board board = boardService.findBoard(boardId);
+        return new ResponseEntity<>(boardMapper.boardToBoardGetResponseDto(board), HttpStatus.OK);
     }
 
     @Operation(summary = "집사생활 새 글 작성하기",

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardCommentResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardCommentResponseDto.java
@@ -1,0 +1,30 @@
+package com.twentyfour_seven.catvillage.board.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardCommentResponseDto {
+    private Long boardCommentId;
+    private String body;
+    private String name;
+    private Long likeCount;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public BoardCommentResponseDto(Long boardCommentId, String body, String name, Long likeCount, LocalDateTime createdDate) {
+        this.boardCommentId = boardCommentId;
+        this.body = body;
+        this.name = name;
+        this.likeCount = likeCount;
+        this.createdDate = createdDate;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
@@ -26,10 +26,10 @@ public class BoardGetResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdDate;
     private Boolean isLike;
-    private List<BoardCommentResponseDto> comments;
+    private List<BoardUserCommentResponseDto> comments;
 
     @Builder
-    public BoardGetResponseDto(Long boardId, String title, String body, String name, List<BoardTagDto> tags, List<PictureDto> pictures, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate, Boolean isLike, List<BoardCommentResponseDto> comments) {
+    public BoardGetResponseDto(Long boardId, String title, String body, String name, List<BoardTagDto> tags, List<PictureDto> pictures, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate, Boolean isLike, List<BoardUserCommentResponseDto> comments) {
         this.boardId = boardId;
         this.title = title;
         this.body = body;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
@@ -1,0 +1,46 @@
+package com.twentyfour_seven.catvillage.board.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardGetResponseDto {
+    private Long boardId;
+    private String title;
+    private String body;
+    private String name;
+    private List<BoardTagDto> tags;
+    private List<PictureDto> pictures;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+    private Boolean isLike;
+    private List<BoardCommentResponseDto> comments;
+
+    @Builder
+    public BoardGetResponseDto(Long boardId, String title, String body, String name, List<BoardTagDto> tags, List<PictureDto> pictures, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate, Boolean isLike, List<BoardCommentResponseDto> comments) {
+        this.boardId = boardId;
+        this.title = title;
+        this.body = body;
+        this.name = name;
+        this.tags = tags;
+        this.pictures = pictures;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.createdDate = createdDate;
+        this.isLike = isLike;
+        this.comments = comments;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardMultiGetResponse.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardMultiGetResponse.java
@@ -1,0 +1,39 @@
+package com.twentyfour_seven.catvillage.board.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardMultiGetResponse {
+    private Long boardId;
+    private String title;
+    private String name;
+    private List<BoardTagDto> tags;
+    private String picture;
+    private Long viewCount;
+    private Long likeCount;
+    private Long commentCount;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public BoardMultiGetResponse(Long boardId, String title, String name, List<BoardTagDto> tags, String picture, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate) {
+        this.boardId = boardId;
+        this.title = title;
+        this.name = name;
+        this.tags = tags;
+        this.picture = picture;
+        this.viewCount = viewCount;
+        this.likeCount = likeCount;
+        this.commentCount = commentCount;
+        this.createdDate = createdDate;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardUserCommentResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardUserCommentResponseDto.java
@@ -1,0 +1,32 @@
+package com.twentyfour_seven.catvillage.board.dto;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class BoardUserCommentResponseDto {
+    private Long boardCommentId;
+    private String boardTitle;
+    private String body;
+    private Long likeCount;
+    private String link;
+    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+    private LocalDateTime createdDate;
+
+    @Builder
+    public BoardUserCommentResponseDto(Long boardCommentId, String boardTitle, String body, Long likeCount, String link, LocalDateTime createdDate) {
+        this.boardCommentId = boardCommentId;
+        this.boardTitle = boardTitle;
+        this.body = body;
+        this.likeCount = likeCount;
+        this.link = link;
+        this.createdDate = createdDate;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
@@ -1,0 +1,27 @@
+package com.twentyfour_seven.catvillage.board.mapper;
+
+import com.twentyfour_seven.catvillage.board.dto.BoardUserCommentResponseDto;
+import com.twentyfour_seven.catvillage.board.entity.BoardComment;
+import org.mapstruct.Mapper;
+
+import java.util.List;
+
+@Mapper(componentModel = "spring")
+public interface BoardCommentMapper {
+    default BoardUserCommentResponseDto boardCommentToBoardUserCommentResponseDto(BoardComment boardComment) {
+        if(boardComment == null) {
+            return null;
+        } else {
+            return BoardUserCommentResponseDto.builder()
+                    .boardCommentId(boardComment.getBoardCommentId())
+                    .boardTitle(boardComment.getBoard().getTitle())
+                    .body(boardComment.getBody())
+                    .likeCount(boardComment.getLikeCount())
+                    .link("https://catvillage.tk/집사생활/" + boardComment.getBoard().getBoardId())
+                    .createdDate(boardComment.getCreatedDate())
+                    .build();
+        }
+    }
+
+    List<BoardUserCommentResponseDto> boardCommentsToBoardUserCommentResponseDtos(List<BoardComment> boardComments);
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -97,6 +97,7 @@ public interface BoardMapper {
                     .likeCount(board.getLikeCount())
                     .commentCount(board.getCommentCount())
                     .createdDate(board.getCreatedDate())
+                    .isLike(false)  // TODO: Like 기능 추가 후 수정 필요
                     .build();
         }
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -1,12 +1,13 @@
 package com.twentyfour_seven.catvillage.board.mapper;
 
-import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
-import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
-import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
-import com.twentyfour_seven.catvillage.board.dto.BoardTagDto;
+import com.twentyfour_seven.catvillage.board.dto.*;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import org.mapstruct.Mapper;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
 
 @Mapper(componentModel = "spring")
 public interface BoardMapper {
@@ -50,6 +51,52 @@ public interface BoardMapper {
                     .boardId(requestBody.getBoardId())
                     .title(requestBody.getTitle())
                     .body(requestBody.getBody())
+                    .build();
+        }
+    }
+
+    default BoardMultiGetResponse boardToBoardMultiGetResponseDto(Board board) {
+        if(board == null) {
+            return null;
+        } else {
+            return BoardMultiGetResponse.builder()
+                    .boardId(board.getBoardId())
+                    .title(board.getTitle())
+                    .name(board.getUser().getName())
+                    .tags(board.getTagToBoards().stream()
+                            .map(e -> new BoardTagDto(e.getBoardTag()))
+                            .collect(Collectors.toList()))
+                    .picture(board.getPictures().isEmpty() ? "" : board.getPictures().get(0).getPath())
+                    .viewCount(board.getViewCount())
+                    .likeCount(board.getLikeCount())
+                    .commentCount(board.getCommentCount())
+                    .createdDate(board.getCreatedDate())
+                    .build();
+        }
+    }
+
+    List<BoardMultiGetResponse> boardsToBoardMultiGetResponseDtos(List<Board> boards);
+
+    default BoardGetResponseDto boardToBoardGetResponseDto(Board board) {
+        if(board == null) {
+            return null;
+        } else {
+            return BoardGetResponseDto.builder()
+                    .boardId(board.getBoardId())
+                    .title(board.getTitle())
+                    .body(board.getBody())
+                    .name(board.getUser().getName())
+                    .tags(board.getTagToBoards().stream()
+                            .map(e -> new BoardTagDto(e.getBoardTag()))
+                            .collect(Collectors.toList()))
+                    .pictures(board.getPictures().isEmpty() ? new ArrayList<>() :
+                            board.getPictures().stream()
+                                    .map(PictureDto::new)
+                                    .collect(Collectors.toList()))
+                    .viewCount(board.getViewCount())
+                    .likeCount(board.getLikeCount())
+                    .commentCount(board.getCommentCount())
+                    .createdDate(board.getCreatedDate())
                     .build();
         }
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -10,6 +10,9 @@ import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -26,6 +29,15 @@ public class BoardService {
         this.boardRepository = boardRepository;
         this.tagToBoardService = tagToBoardService;
         this.pictureService = pictureService;
+    }
+
+    public Page<Board> findBoards(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("boardId").descending());
+        return boardRepository.findAll(pageRequest);
+    }
+
+    public Board findBoard(Long boardId) {
+        return findVerifiedBoard(boardId);
     }
 
     public Board createBoard(Board board, List<BoardTagDto> tags, List<PictureDto> pictures) {


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활에 등록된 전체 게시글을 pagination을 적용하여 불러올 수 있는 기능 구현
- 집사생활에 등록된 특정 게시글의 내용을 불러올 수 있는 기능 구현

## 코드 변경 이유
- 집사생활에 등록된 전체 게시글을 페이지 기준으로 나누어 불러올 수 있는 로직 추가
- 집사생활에 등록된 특정 게시글의 내용을 불러올 수 있는 로직 추가
- 각각의 createdDate(생성일) 필드는 "yyyy-MM-dd HH:mm:ss" 형태로 변환하여 반환하도록 지정 (예 : 2022-09-30 04:00:00)
- 추가된 API에 대해 Swagger를 통한 API Docs 생성 시 summary 항목 추가 되도록 어노테이션 작성

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardController class
- BoardCommentResponseDto class
- BoardGetResponeDto class
- BoardMultiGetResponseDto class
- BoardUserCommentResponeDto class
- BoardCommentMapper interface
- BoardMapper interface
- BoardService class

## 연결된 이슈
resolved #105
resolved #106

## 자료 (스크린샷 등)
