### PR TITLE
fix: github secrets not working fix

### DIFF
--- a/.github/workflows/PR-build.yml
+++ b/.github/workflows/PR-build.yml
@@ -14,8 +14,8 @@ on:
       - 'main'
     paths-ignore: [ "client/**" ]
 
-env:
-  RESOURCE_PATH: ./server/catvillage/src/main/resources-prod/application.yml
+#env:
+#  RESOURCE_PATH: ./server/catvillage/src/main/resources-prod/application.yml
 
 permissions:
   contents: read
@@ -26,24 +26,36 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up JDK 11
-      uses: actions/setup-java@v3
-      with:
-        java-version: '11'
-        distribution: 'temurin'
+      - name: Checkout
+        uses: actions/checkout@v3
 
-    - name: Set yaml file
-      uses: microsoft/variable-substitution@v1
-      with:
-        files: ${{ env.RESOURCE_PATH }}
-      env:
-        jwt.secret: ${{ secrets.JWT_SECRET }}
-        cloud.aws.credentials.accessKey: ${{ secrets.AWS_ACCESS_KEY }}
-        cloud.aws.credentials.secretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      - name: Set up JDK 11
+        uses: actions/setup-java@v3
+        with:
+          java-version: '11'
+          distribution: 'temurin'
 
-    - name: Build with Gradle
-      uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
-      with:
-        arguments: build -Pprofile=prod
-        build-root-directory: server/catvillage
+  #    - name: Set yaml file
+  #      uses: microsoft/variable-substitution@v1
+  #      with:
+  #        files: ${{ env.RESOURCE_PATH }}
+  #      env:
+  #        jwt.secret: ${{ secrets.JWT_SECRET }}
+  #        cloud.aws.credentials.accessKey: ${{ secrets.AWS_ACCESS_KEY }}
+  #        cloud.aws.credentials.secretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+
+      - name: Build with Gradle
+        uses: gradle/gradle-build-action@67421db6bd0bf253fb4bd25b31ebb98943c375e1
+        with:
+          arguments: build -Pprofile=prod
+          build-root-directory: server/catvillage
+        env:
+          RDS_ENDPOINT: ${{ secrets.ENDPOINT }}
+          RDS_PORT: ${{ secrets.PORT }}
+          RDS_USERNAME: ${{ secrets.USER }}
+          RDS_PASSWORD: ${{ secrets.PASSWORD }}
+          KAKAO_API_KEY: ${{ secrets.KAKAO_REST_API_KEY }}
+          KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+          JWT_SECRET: ${{ secrets.JWT_SECRET }}
+          AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+          AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}

--- a/.github/workflows/auto-build.yml
+++ b/.github/workflows/auto-build.yml
@@ -35,14 +35,14 @@ jobs:
         java-version: '11'
         distribution: 'temurin'
 
-    - name: Set yaml file
-      uses: microsoft/variable-substitution@v1
-      with:
-        files: ${{ env.RESOURCE_PATH }}
-      env:
-        jwt.secret: ${{ secrets.JWT_SECRET }}
-        cloud.aws.credentials.accessKey: ${{ secrets.AWS_ACCESS_KEY }}
-        cloud.aws.credentials.secretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+#    - name: Set yaml file
+#      uses: microsoft/variable-substitution@v1
+#      with:
+#        files: ${{ env.RESOURCE_PATH }}
+#      env:
+#        jwt.secret: ${{ secrets.JWT_SECRET }}
+#        cloud.aws.credentials.accessKey: ${{ secrets.AWS_ACCESS_KEY }}
+#        cloud.aws.credentials.secretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
     
     # grant execute permission for gradlew
     - name : Grant execute permission for gradlew
@@ -53,6 +53,16 @@ jobs:
     - name: Build with Gradle
       run: cd server/catvillage; ./gradlew build -Pprofile=prod
       shell: bash
+      env:
+        RDS_ENDPOINT: ${{ secrets.ENDPOINT }}
+        RDS_PORT: ${{ secrets.PORT }}
+        RDS_USERNAME: ${{ secrets.USER }}
+        RDS_PASSWORD: ${{ secrets.PASSWORD }}
+        KAKAO_API_KEY: ${{ secrets.KAKAO_REST_API_KEY }}
+        KAKAO_CLIENT_SECRET: ${{ secrets.KAKAO_CLIENT_SECRET }}
+        JWT_SECRET: ${{ secrets.JWT_SECRET }}
+        AWS_ACCESS_KEY: ${{ secrets.AWS_ACCESS_KEY }}
+        AWS_SECRET_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
 
     # build한 후 프로젝트를 압축합니다.
     - name: Make zip file

--- a/server/catvillage/src/main/resources-prod/application.yml
+++ b/server/catvillage/src/main/resources-prod/application.yml
@@ -4,9 +4,9 @@ spring:
     include: common
   datasource:
     driver-class-name: org.mariadb.jdbc.Driver
-    url: jdbc:mariadb://${{ secrets.ENDPOINT }}:${{ secrets.PORT }}/cat-village?serverTimezone=UTC&characterEncoding=utf8mb4
-    username: ${{ secrets.USER }}
-    password: ${{ secrets.PASSWORD }}
+    url: jdbc:mariadb://${RDS_ENDPOINT}:${RDS_PORT}/cat-village?serverTimezone=UTC&characterEncoding=utf8mb4
+    username: ${RDS_USER}
+    password: ${RDS_PASSWORD}
   jpa:
     database-platform: org.hibernate.dialect.MariaDB103Dialect
     open-in-view: false
@@ -22,8 +22,8 @@ spring:
       client:
         registration:
           kakao:
-            client-id: ${{ secrets.KAKAO_REST_API_KEY }}
-            client-secret: ${{ secrets.KAKAO_CLIENT_SECRET }}
+            client-id: ${KAKAO_API_KEY}
+            client-secret: ${KAKAO_CLIENT_SECRET}
 logging:
   level:
     org:
@@ -34,9 +34,9 @@ logging:
             sql:
               BasicBinder: TRACE
 jwt:
-  secret: ${{ secrets.JWT_SECRET }}
+  secret: ${JWT_SECRET}
 cloud:
   aws:
     credentials:
-      accessKey: ${{ secrets.AWS_ACCESS_KEY }}
-      secretKey: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+      accessKey: ${AWS_ACCESS_KEY}
+      secretKey: ${AWS_SECRET_KEY}


### PR DESCRIPTION
## 주요 변경 사항
- github actions로 CI/CD 구현한 항목에서 github secrets가 정상적으로 작동하지 않는 문제 수정
- env로 secrets를 재정의 하던 구문 주석

## 코드 변경 이유
- 좀 더 자세히 찾아보니 github secrets를 등록 후 사용할 때 env로 재정의를 해줘야지 적용이 되는 것을 파악
- "secrets: inherit"을 사용하면 env 재정의가 없어도 동작을 한다는 내용을 찾아서 적용

## 코드 리뷰 시 중점적으로 봐야할 부분
- deploy-test-custom 부분

## 연결된 이슈

## 자료 (스크린샷 등)
