### PR TITLE
feat: 냥이생활 전체 피드 보기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
@@ -5,12 +5,14 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
 import javax.validation.constraints.Max;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Validated
 public class PictureDto {
     @Length(max = 500)
     private String picture;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -1,6 +1,9 @@
 package com.twentyfour_seven.catvillage.feed.controller;
 
+import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.FeedGetResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedMultiGetResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedMultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
@@ -11,9 +14,14 @@ import com.twentyfour_seven.catvillage.feed.mapper.FeedTagMapper;
 import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
+import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
+import com.twentyfour_seven.catvillage.user.entity.Follow;
 import io.swagger.v3.oas.annotations.Operation;
+import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
@@ -21,6 +29,7 @@ import org.springframework.web.bind.annotation.*;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @RestController
 @RequestMapping("/냥이생활")
@@ -49,7 +58,7 @@ public class FeedController {
 
     @Operation(summary = "냥이생활 피드 작성하기")
     @PostMapping
-    public ResponseEntity postFeed (@RequestBody @Valid FeedPostDto feedPostDto) {
+    public ResponseEntity postFeed(@RequestBody @Valid FeedPostDto feedPostDto) {
         Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);
         Feed createFeed = feedService.createFeed(feed, feedPostDto.getCatId());
         List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());
@@ -57,14 +66,42 @@ public class FeedController {
         return new ResponseEntity<>(feedMapper.feedToFeedResponseDto(createFeed), HttpStatus.CREATED);
     }
 
+    @Operation(summary = "냥이생활 특정 피드 보기")
     @GetMapping("/{feeds-id}")
-    public ResponseEntity getFeed (@PathVariable("feeds-id") @Positive long feedId) {
+    public ResponseEntity getFeed(@PathVariable("feeds-id") @Positive long feedId) {
         Feed feed = feedService.findFeed(feedId);
-        List<FeedTag> feedTags  = feedTagService.findFeedTags(feed);
+        List<FeedTag> feedTags = feedTagService.findFeedTags(feed);
         List<FeedComment> comments = feedCommentService.findComments(feed);
         FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(feed);
         response.setTags(feedTagMapper.feedTagsToFeedTagDtos(feedTags));
         response.setComments(feedCommentMapper.feedCommentsToFeedCommentGetDtos(comments));
+        return new ResponseEntity<>(response, HttpStatus.OK);
+    }
+
+    @Operation(summary = "냥이생활 전체 게시글 보기")
+    @GetMapping
+    public ResponseEntity getFeeds(@RequestParam @Positive int page,
+                                   @RequestParam @Positive int size,
+                                   @AuthenticationPrincipal User user) {
+        // page 와 size 정보를 토대로 Page 생성
+        Page<Feed> feeds = feedService.findFeeds(page - 1, size);
+
+        // Page 의 feed 컨텐츠를 형식에 맞는 Dto 로 매핑
+        List<FeedMultiGetResponseDto> feedResponseDto = feedMapper.feedsToFeedMultiGetResponseDtos(feeds.getContent());
+
+        // TODO: Like 구현 후 로그인한 유저가 글마다 좋아요를 눌렀는지 여부 feedResponseDto 에 반영 로직 필요 !
+
+        // 응답 객체 생성
+        FeedMultiResponseDto response = new FeedMultiResponseDto(feedResponseDto, feeds);
+
+        // 로그인 정보가 있다면 유저가 팔로우한 유저의 고양이 정보 가져오기
+        if (user != null) {
+            List<FollowFeedGetDto> follows = feedService.findFollows(user).stream().map(
+                    cat -> new FollowFeedGetDto(cat.getImage(), cat.getCatId())
+            ).collect(Collectors.toList());
+            response.setFollow(follows);
+        }
+
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
@@ -1,0 +1,25 @@
+package com.twentyfour_seven.catvillage.feed.dto;
+
+import io.swagger.annotations.ApiParam;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FeedMultiGetResponseDto {
+    @ApiParam(value = "냥이생활 피드 식별자(id)")
+    private long feedId;
+    @ApiParam(value = "특정 피드의 대표이미지")
+    private String image;
+    @ApiParam(value = "로그인한 사용자가 좋아요를 눌렀는지 여부")
+    private boolean isLike;
+
+    public FeedMultiGetResponseDto(long feedId, String image) {
+        this.feedId = feedId;
+        this.image = image;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiResponseDto.java
@@ -1,0 +1,29 @@
+package com.twentyfour_seven.catvillage.feed.dto;
+
+import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+public class FeedMultiResponseDto {
+    private List<FollowFeedGetDto> follow;
+    private List<FeedMultiGetResponseDto> feed;
+    private int page;
+    private int pageSize;
+    private int totalPages;
+    private long totalElements;
+
+    public FeedMultiResponseDto(List<FeedMultiGetResponseDto> feed, Page pageInfo) {
+        this.feed = feed;
+        this.page = pageInfo.getNumber() + 1;
+        this.pageSize = pageInfo.getSize();
+        this.totalPages = pageInfo.getTotalPages();
+        this.totalElements = pageInfo.getTotalElements();
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
@@ -4,13 +4,17 @@ import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Validated
 public class FeedPostDto {
+    @Positive
     private long catId;
     private List<PictureDto> pictures;
     private String body;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedTagDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedTagDto.java
@@ -4,11 +4,15 @@ import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Validated
 public class FeedTagDto {
+    @Length(max = 15)
     private String tag;
 
     public FeedTagDto (FeedTag feedTag) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -3,11 +3,13 @@ package com.twentyfour_seven.catvillage.feed.mapper;
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.feed.dto.FeedGetResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedMultiGetResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
 import com.twentyfour_seven.catvillage.feed.dto.FeedResponseDto;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
+import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -56,4 +58,11 @@ public interface FeedMapper {
     }
 
     List<FeedGetResponseDto> feedsToFeedGetResponseDtos(List<Feed> feeds);
+
+    default FeedMultiGetResponseDto feedToFeedMultiGetResponseDto(Feed feed) {
+        return new FeedMultiGetResponseDto(
+                feed.getFeedId(),
+                feed.getPictures().get(0).getPath());
+    }
+    List<FeedMultiGetResponseDto> feedsToFeedMultiGetResponseDtos(List<Feed> feeds);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -55,7 +55,10 @@ public class FeedService {
     }
 
     private Feed findVerifiedFeed(long feedId) {
-        return null;
+        Optional<Feed> optionalFeed = feedRepository.findById(feedId);
+        Feed findFeed = optionalFeed
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.FEED_NOT_FOUND));
+        return findFeed;
     }
 
     public Page<Feed> findFeeds(int page, int size) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -7,8 +7,17 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.repository.FeedRepository;
+import com.twentyfour_seven.catvillage.user.controller.FollowService;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.repository.UserRepository;
+import com.twentyfour_seven.catvillage.user.service.UserService;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Optional;
 
 @Service
@@ -16,13 +25,19 @@ public class FeedService {
     private final FeedRepository feedRepository;
     private final CatService catService;
     private final PictureService pictureService;
+    private final UserService userService;
+    private final FollowService followService;
 
     public FeedService(FeedRepository feedRepository,
                        CatService catService,
-                       PictureService pictureService) {
+                       PictureService pictureService,
+                       UserService userService,
+                       FollowService followService) {
         this.feedRepository = feedRepository;
         this.catService = catService;
         this.pictureService = pictureService;
+        this.userService = userService;
+        this.followService = followService;
     }
 
     public Feed createFeed(Feed feed, long catId) {
@@ -40,9 +55,25 @@ public class FeedService {
     }
 
     private Feed findVerifiedFeed(long feedId) {
-        Optional<Feed> optionalFeed = feedRepository.findById(feedId);
-        Feed findFeed = optionalFeed
-                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.FEED_NOT_FOUND));
-        return findFeed;
+        return null;
+    }
+
+    public Page<Feed> findFeeds(int page, int size) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("feedId").descending());
+        return feedRepository.findAll(pageRequest);
+    }
+
+    public List<Cat> findFollows(org.springframework.security.core.userdetails.User user) {
+        User loginUser = userService.findVerifiedEmail(user.getUsername());
+        List<User> followUsers = followService.findFollowsInFeed(loginUser);
+        List<Cat> followCats = new ArrayList<>();
+        followUsers.forEach(
+                followUser -> {
+                    followUser.getCats().forEach(
+                            cat -> followCats.add(cat)
+                    );
+                }
+        );
+        return followCats;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/FollowService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/FollowService.java
@@ -1,0 +1,28 @@
+package com.twentyfour_seven.catvillage.user.controller;
+
+import com.twentyfour_seven.catvillage.user.entity.Follow;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.repository.FollowRepository;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+public class FollowService {
+    private final FollowRepository followRepository;
+
+    public FollowService(FollowRepository followRepository) {
+        this.followRepository = followRepository;
+    }
+
+    // 냥이생활 전체 피드보기에서 특정 유저의 팔로워 목록 가져오는 로직
+    public List<User> findFollowsInFeed(User user) {
+        List<Follow> follows = followRepository.findByMember(user);
+        if (follows == null) {
+            return null;
+        }
+        List<User> targets = follows.stream().map(follow -> follow.getTarget()).collect(Collectors.toList());
+        return targets;
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/FollowFeedGetDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/FollowFeedGetDto.java
@@ -1,0 +1,15 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+public class FollowFeedGetDto {
+    private String profileImage;
+    private long catId;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/repository/FollowRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/repository/FollowRepository.java
@@ -1,0 +1,11 @@
+package com.twentyfour_seven.catvillage.user.repository;
+
+import com.twentyfour_seven.catvillage.user.entity.Follow;
+import com.twentyfour_seven.catvillage.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+    List<Follow> findByMember (User member);
+}


### PR DESCRIPTION
## 주요 변경 사항
- user.service 패키지 내 FollowService 생성 및 feed에서 사용할 특정 유저의 팔로우 목록 가져오는 로직 구현
- user.repository 패키지내 FollowRepository 생성
- FeedController에 getFeeds 메서드 추가
- FeedService에 findFeeds, findfollow 메서드 추가

## 코드 변경 이유
- 냥이생활 전체 피드 보기 요청 시 로그인한 유저가 팔로우한 유저의 고양이 정보(프로필 이미지)가 필요하여 팔로우 관련 로직을 구현했습니다.
- feed 페이지화하는 메서드와 유저가 팔로우한 고양이 리스트 반환하는 메서드 따로 작성했습니다.
- 로그인 정보가 없을 시에는 팔로우 리스트 가져오는 메서드를 호출하지 않습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- FeedController의 getFeeds 부분은 컨트롤러에 너무 많은 로직이 들어가서 나중에 리팩토링이 필요합니다.
- getFeeds에 좋아요 눌렀는지 여부를 담는 로직은 빠져있어서 나중에 추가해야합니다. (TODO 주석표시 부분)
- FollowService, FollowRepository
- FeedService

## 연결된 이슈
- close #94 

## 자료 (스크린샷 등)
