### PR TITLE
fix: 원격 저장소의 env 폴더 제거

### DIFF
--- a/client/env/.env.dev
+++ b/client/env/.env.dev
@@ -1,2 +1,0 @@
-PUBLIC_URL=http://localhost:3000
-APP_API=

--- a/client/env/.env.prod
+++ b/client/env/.env.prod
@@ -1,2 +1,0 @@
-PUBLIC_URL=
-APP_API=


### PR DESCRIPTION
## 주요 변경 사항
- env 폴더를 .gitinore에 추가해도 변경 사항이 추적되는 현상을 발견했습니다.
- 원격 저장소에 env 폴더가 이미 업로드되어 있어 변경 사항이 추적되고 있는 
- 따라서 다음과 같은 명령어로 원격 저장소의 env 폴더를 제거했습니다.

```
// 원격 저장소에 있는 파일 또는 폴더를 제거하는 명령어
$ git rm --cached -r [파일명 또는 폴더명]

// client의 env 폴더를 원격 저장소에서 제거합니다.
$ git rm --cached -r env/
```
## 코드 변경 이유
## 코드 리뷰 시 중점적으로 봐야할 부분
- 만약 merge 후 ``git pull origin dev`` 명령어를 입력했을 때 로컬 저장소의 env 폴더도 같이 삭제되면 알려주시기 바랍니다.

## 연결된 이슈
## 자료 (스크린샷 등)
<img width="1435" alt="스크린샷 2022-09-30 오후 4 56 33" src="https://user-images.githubusercontent.com/88873956/193221126-f4089630-66bc-4dca-a0e6-da311b931e3c.png">

[[Git/GitHub] - GitHub에 잘못 올라간 파일 제거하기(.gitignore)](https://zzang9ha.tistory.com/359)
