### PR TITLE
fix: post 시 복합 PK 부분 에러 fix 및 고양이 등록시 성별 에러 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoardId.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/TagToBoardId.java
@@ -10,6 +10,6 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TagToBoardId implements Serializable {
-    private Board board;
-    private BoardTag boardTag;
+    private Long board;
+    private Long boardTag;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
@@ -23,7 +23,7 @@ public class CatPostDto {
 
     private String breed;
 
-    @Pattern(regexp = "\\^[mf]\\$")
+    @Pattern(regexp = "^[mf]$")
     private String sex;
 
     private int weight;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCatId.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/TagToCatId.java
@@ -11,6 +11,6 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TagToCatId implements Serializable {
-    private CatTag catTag;
-    private Cat cat;
+    private Long catTag;
+    private Long cat;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -9,7 +9,6 @@ import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
-import org.springframework.web.server.MethodNotAllowedException;
 
 import java.util.List;
 import java.util.Optional;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/TagToFeedId.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/TagToFeedId.java
@@ -10,6 +10,6 @@ import java.io.Serializable;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TagToFeedId implements Serializable {
-    private Feed feed;
-    private FeedTag feedTag;
+    private Long feed;
+    private Long feedTag;
 }


### PR DESCRIPTION
## 주요 변경 사항
- CatPostDto에 sex(성별) 부분 Pettern의 regexp 정규표현식 수정
- ~Id 클래스 필드 타입 Long으로 수정


## 코드 변경 이유
- 고양이 등록시 성별 부분을 올바르게 입력하여도 잘못된 형식이라는 오류 발생하여 잘못된 정규표현식 수정하였습니다.
- 다대다 매핑에서 1대다 다대1 로 나눠주는 클래스에서 id를 따로 지정하지 않고 양쪽의 id 값을 합쳐서 (Serializable, IdClass 사용)사용한 부분에서 Id 값이 매핑이 안되는 오류 발생하여 Id 클래스의 필드를 실제 Id값인 Long 타입으로 수정하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
이부분을 지우고 내용을 적어주세요.

## 연결된 이슈
- close #159 
- close #155 

## 자료 (스크린샷 등)
