### PR TITLE
feat: 냥이생활 글 수정하기 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -102,11 +102,12 @@ public class FeedController {
 
     @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.")
     @PatchMapping("{feeds-id}")
-    public ResponseEntity patchFeed(@PathVariable("feeds-id") @Positive long feedsId,
+    public ResponseEntity patchFeed(@PathVariable("feeds-id") @Positive long feedId,
                                     @RequestBody @Valid FeedPostDto feedPostDto,
                                     @AuthenticationPrincipal User user) {
         // feedService의 updateFeed 메서드에서 feed, pictures update
-        Feed updateFeed = feedService.updateFeed(feedMapper.feedPostDtoToFeed(feedPostDto), user.getUsername());
+        Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);
+        Feed updateFeed = feedService.updateFeed(feedId, feed, user.getUsername());
 
         // FeedPostDto의 FeedTagDto 리스트를 FeedTag 리스트로 변환
         List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -1,10 +1,6 @@
 package com.twentyfour_seven.catvillage.feed.controller;
 
-import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedGetResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedMultiGetResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedMultiResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
+import com.twentyfour_seven.catvillage.feed.dto.*;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
 import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
@@ -15,7 +11,6 @@ import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
 import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
-import com.twentyfour_seven.catvillage.user.entity.Follow;
 import io.swagger.v3.oas.annotations.Operation;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
@@ -104,4 +99,25 @@ public class FeedController {
 
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
+
+    @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.")
+    @PatchMapping("{feeds-id}")
+    public ResponseEntity patchFeed(@PathVariable @Positive long feedsId,
+                                    @RequestBody @Valid FeedPostDto feedPostDto,
+                                    @AuthenticationPrincipal User user) {
+        // feedService의 updateFeed 메서드에서 feed, pictures update
+        Feed updateFeed = feedService.updateFeed(feedMapper.feedPostDtoToFeed(feedPostDto), user.getUsername());
+
+        // FeedPostDto의 FeedTagDto 리스트를 FeedTag 리스트로 변환
+        List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());
+
+        // feedTagService의 메서드에서 FeedTag와 TagToFeed update
+        List<FeedTag> updateTags = feedTagService.updateTags(updateFeed, feedTags);
+
+        // responseDto 생성하여 값 대입
+        FeedResponseDto response = feedMapper.feedToFeedResponseDto(updateFeed);
+        response.setTags(feedTagMapper.feedTagsToFeedTagDtos(updateTags));
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -102,7 +102,7 @@ public class FeedController {
 
     @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.")
     @PatchMapping("{feeds-id}")
-    public ResponseEntity patchFeed(@PathVariable @Positive long feedsId,
+    public ResponseEntity patchFeed(@PathVariable("feeds-id") @Positive long feedsId,
                                     @RequestBody @Valid FeedPostDto feedPostDto,
                                     @AuthenticationPrincipal User user) {
         // feedService의 updateFeed 메서드에서 feed, pictures update

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
@@ -22,6 +22,7 @@ public class Feed extends DateTable {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long feedId;
 
+    @Setter
     @Column(name = "BODY", length = 1000)
     private String body;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/repository/FeedTagRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/repository/FeedTagRepository.java
@@ -3,5 +3,8 @@ package com.twentyfour_seven.catvillage.feed.repository;
 import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.Optional;
+
 public interface FeedTagRepository extends JpaRepository<FeedTag, Long> {
+    Optional<FeedTag> findByTagName(String tagName);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.twentyfour_seven.catvillage.feed.service;
 
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
@@ -11,6 +12,7 @@ import com.twentyfour_seven.catvillage.user.controller.FollowService;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.repository.UserRepository;
 import com.twentyfour_seven.catvillage.user.service.UserService;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -78,5 +80,55 @@ public class FeedService {
                 }
         );
         return followCats;
+    }
+
+    public Feed updateFeed(Feed feed, String email) {
+        // feedId로 저장되있던 feed 정보를 불러옴
+        Feed findFeed = findVerifiedFeed(feed.getFeedId());
+
+        // 글을 처음 작성한 유저와 로그인한 유저가 동일한지 확인하고 아니면 Exception throw
+        if (!findFeed.getCat().getUser().getEmail().equals(email)) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+
+        // Feed 내용 업데이트
+        Feed updateFeed = findFeed;
+        if (findFeed.getBody() != feed.getBody()) {
+            updateFeed.setBody(feed.getBody());
+        }
+
+        // Picture 업데이트를 위해 source, definition의 path만 따로 저장
+        List<String> picturePaths1 = new ArrayList<>();
+        List<String> picturePaths2 = new ArrayList<>();
+        feed.getPictures().forEach(
+                picture -> {
+                    picturePaths1.add(picture.getPath());
+                }
+        );
+        updateFeed.getPictures().forEach(
+                picture -> {
+                    picturePaths2.add(picture.getPath());
+                }
+        );
+        // 삭제된 이미지는 DB에서 제거 후 리스트에서도 제거
+        findFeed.getPictures().forEach(
+                picture -> {
+                    if (!picturePaths1.contains(picture.getPath())) {
+                        pictureService.removePicture(picture.getPictureId());
+                        findFeed.getPictures().remove(picture);
+                    }
+                }
+        );
+
+        // 추가된 이미지는 DB에 추가 후 리스트에도 추가
+        feed.getPictures().forEach(
+                picture -> {
+                    if (!picturePaths2.contains(picture.getPath())) {
+                        picture = pictureService.createPicture(picture);
+                        findFeed.getPictures().add(picture);
+                    }
+                }
+        );
+        return feedRepository.save(updateFeed);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -115,10 +115,10 @@ public class FeedService {
                 picture -> {
                     if (!picturePaths1.contains(picture.getPath())) {
                         pictureService.removePicture(picture.getPictureId());
-                        findFeed.getPictures().remove(picture);
                     }
                 }
         );
+        findFeed.getPictures().removeIf(picture -> !picturePaths1.contains(picture.getPath()));
 
         // 추가된 이미지는 DB에 추가 후 리스트에도 추가
         feed.getPictures().forEach(

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -82,9 +82,9 @@ public class FeedService {
         return followCats;
     }
 
-    public Feed updateFeed(Feed feed, String email) {
+    public Feed updateFeed(long feedId, Feed feed, String email) {
         // feedId로 저장되있던 feed 정보를 불러옴
-        Feed findFeed = findVerifiedFeed(feed.getFeedId());
+        Feed findFeed = findVerifiedFeed(feedId);
 
         // 글을 처음 작성한 유저와 로그인한 유저가 동일한지 확인하고 아니면 Exception throw
         if (!findFeed.getCat().getUser().getEmail().equals(email)) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
@@ -3,12 +3,15 @@ package com.twentyfour_seven.catvillage.feed.service;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedTag;
 import com.twentyfour_seven.catvillage.feed.entity.TagToFeed;
+import com.twentyfour_seven.catvillage.feed.entity.TagToFeedId;
 import com.twentyfour_seven.catvillage.feed.repository.FeedTagRepository;
 import com.twentyfour_seven.catvillage.feed.repository.TagToFeedRepository;
+import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 @Service
 public class FeedTagService {
@@ -40,5 +43,41 @@ public class FeedTagService {
         List<FeedTag> feedTags = new ArrayList<>();
         feed.getTagToFeeds().forEach(tagToFeed -> feedTags.add(tagToFeed.getFeedTag()));
         return feedTags;
+    }
+
+    public List<FeedTag> updateTags(Feed feed, List<FeedTag> feedTags) {
+        feedTags.forEach(
+                feedTag -> {
+                    // 입력받은 모든 FeedTag, TagToFeed 업데이트
+                    feedTag = updateFeedTag(feedTag);
+                    updateTagToFeed(new TagToFeed(feed, feedTag));
+                }
+        );
+        // 유저가 제거한 Tag 확인하여 TagToFeed 제거
+        feed.getTagToFeeds().stream().forEach(
+                tagToFeed -> {
+                    if (!feedTags.contains(tagToFeed.getFeedTag())) {
+                        tagToFeedRepository.delete(tagToFeed);
+                    }
+                }
+        );
+        return feedTags;
+    }
+
+    private FeedTag updateFeedTag(FeedTag feedTag) {
+        // feedTag 가 DB에 있는지 확인
+        Optional<FeedTag> optionalFeedTag = feedTagRepository.findByTagName(feedTag.getTagName());
+        // DB에 없다면 feedTag 저장
+        if(!optionalFeedTag.isPresent()) {
+            return feedTagRepository.save(feedTag);
+        }
+        return feedTag;
+    }
+
+    private TagToFeed updateTagToFeed(TagToFeed tagToFeed) {
+        // db에 있는지 찾기 위해 id 클래스 생성
+        TagToFeedId id = new TagToFeedId(tagToFeed.getFeed().getFeedId(), tagToFeed.getFeedTag().getFeedTagId());
+        Optional<TagToFeed> optionalTagToFeed = tagToFeedRepository.findById(id);
+        return optionalTagToFeed.orElse(tagToFeedRepository.save(tagToFeed));
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- FeedController에 patchFeed 메서드 구현
- FeedService에서 pictures, feed의 body 업데이트 하는 updateFeed 메서드 구현
- FeedTagService에 tag 정보 업데이트하는 updateTags 구현

## 코드 변경 이유
- 냥이생활 피드 수정 기능에 필요한 로직들을 구현했습니다.
- picture와 tag는 기존 DB에 없던 내용이 추가되면 DB에 추가하고 있던 내용이 없다면 삭제하도록 하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- FeedService에서 Picture와 Feed 정보가 업데이트 되는 부분
- FeedTagService에 업데이트 되는 부분

## 연결된 이슈
- close #96 

## 자료 (스크린샷 등)
