### PR TITLE
feat: 일반 회원가입 구현

### DIFF
--- a/client/.eslintrc.js
+++ b/client/.eslintrc.js
@@ -41,6 +41,7 @@ module.exports = {
       2,
       { namedComponents: 'arrow-function' }, // 함수형 컴포넌트 형식 정의
     ],
+    'no-param-reassign': 0,
     'react/require-default-props': 'off',
   },
 }

--- a/client/src/@types/user.ts
+++ b/client/src/@types/user.ts
@@ -1,0 +1,19 @@
+export interface User {
+  isLoading: boolean
+  isSignup: boolean
+  userInfo: UserInfo | null
+}
+
+export interface UserInfo {
+  email: string
+  password: string
+  location: null
+  name: string
+  profileImage: string | null
+}
+
+// 로그인 요청 페이로드의 타입을 미리 생성했습니다.
+// export interface LoginPayload {
+//   email: string
+//   password: string
+// }

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -3,20 +3,24 @@ import { BrowserRouter } from 'react-router-dom'
 import { ThemeProvider } from 'styled-components'
 import { GlobalStyle } from '@Styles/GlobalStyle'
 import theme from '@Styles/theme'
+import { Provider } from 'react-redux'
 import AppRoutes from './routes'
+import { setupStore } from './redux/store/index'
 
 const loading = <div>화면을 불러오는 중 입니다.</div>
 
 const App = () => {
   return (
-    <BrowserRouter>
-      <ThemeProvider theme={theme}>
-        <GlobalStyle />
-        <Suspense fallback={loading}>
-          <AppRoutes />
-        </Suspense>
-      </ThemeProvider>
-    </BrowserRouter>
+    <Provider store={setupStore()}>
+      <BrowserRouter>
+        <ThemeProvider theme={theme}>
+          <GlobalStyle />
+          <Suspense fallback={loading}>
+            <AppRoutes />
+          </Suspense>
+        </ThemeProvider>
+      </BrowserRouter>
+    </Provider>
   )
 }
 

--- a/client/src/pages/Signup/Signup.tsx
+++ b/client/src/pages/Signup/Signup.tsx
@@ -2,6 +2,8 @@ import { useState, FC, useRef } from 'react'
 import SocialLoginButton from '@Modules/SocialLoginButton'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import * as S from './Signup.style'
+import { useAppDispatch } from '@/redux/store'
+import { signupAsync } from '@/redux/actions/userAction'
 
 export interface FormValue {
   email: string
@@ -20,13 +22,24 @@ const Signup: FC = () => {
   const [isShown, setIsSHown] = useState(false)
   const passwordRef = useRef<string | null>(null)
   passwordRef.current = watch('password')
+  const dispatch = useAppDispatch()
 
   const togglePassword = () => {
     setIsSHown(isShown => !isShown)
   }
 
   const onSubmitHandler: SubmitHandler<FormValue> = data => {
-    console.log(data)
+    const defaultName = `집사${Math.floor(Math.random() * 10000) + 1}`
+
+    dispatch(
+      signupAsync({
+        email: data.email,
+        password: data.password,
+        location: null,
+        name: defaultName,
+        profileImage: null,
+      }),
+    )
   }
 
   const handleSocialLogin = () => {

--- a/client/src/redux/actions/userAction.ts
+++ b/client/src/redux/actions/userAction.ts
@@ -1,0 +1,17 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { UserInfo } from '@Types/user'
+import { axiosInstance } from '@Utils/instance'
+import { CreateAsyncThunkTypes } from '../store'
+
+export const signupAsync = createAsyncThunk<
+  undefined,
+  UserInfo,
+  CreateAsyncThunkTypes
+>('user/signup', async (payload, thunkAPI) => {
+  try {
+    const res = await axiosInstance.post('/signup', payload)
+    return res.data
+  } catch (error: any) {
+    return thunkAPI.rejectWithValue(error.message)
+  }
+})

--- a/client/src/redux/reducers/userSlice.ts
+++ b/client/src/redux/reducers/userSlice.ts
@@ -1,0 +1,32 @@
+import { createSlice, Reducer } from '@reduxjs/toolkit'
+import { User } from '@Types/user'
+import { signupAsync } from '../actions/userAction'
+
+const initialState: User = {
+  isLoading: true,
+  isSignup: false,
+  userInfo: null,
+}
+
+const userSlice = createSlice({
+  name: 'user',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      // 회원가입
+      .addCase(signupAsync.pending, state => {
+        state.isSignup = false
+      })
+      .addCase(signupAsync.fulfilled, state => {
+        state.isLoading = false
+        state.isSignup = true
+        alert('회원가입에 성공했습니다.')
+      })
+      .addCase(signupAsync.rejected, state => {
+        state.isLoading = false
+        alert('회원가입에 실패했습니다.')
+      })
+  },
+})
+export const userReducer: Reducer<typeof initialState> = userSlice.reducer

--- a/client/src/redux/store/index.ts
+++ b/client/src/redux/store/index.ts
@@ -1,0 +1,33 @@
+import {
+  configureStore,
+  combineReducers,
+  PreloadedState,
+} from '@reduxjs/toolkit'
+import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux'
+
+import { userReducer } from '../reducers/userSlice'
+
+const rootReducer = combineReducers({
+  /* 슬라이스로 생성한 리듀서는 여기에 추가하면 됩니다. */
+  user: userReducer,
+})
+
+export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
+  return configureStore({
+    reducer: rootReducer,
+    preloadedState,
+  })
+}
+
+export const useAppDispatch: () => AppDispatch = useDispatch
+export const useAppSelector: TypedUseSelectorHook<RootState> = useSelector
+
+export type RootState = ReturnType<typeof rootReducer>
+export type AppStore = ReturnType<typeof setupStore>
+export type AppDispatch = AppStore['dispatch']
+
+export type CreateAsyncThunkTypes = {
+  dispatch: AppDispatch
+  state: RootState
+  rejectValue: string
+}

--- a/client/src/utils/instance.ts
+++ b/client/src/utils/instance.ts
@@ -1,0 +1,5 @@
+import axios from 'axios'
+
+export const axiosInstance = axios.create({
+  baseURL: process.env.APP_API,
+})


### PR DESCRIPTION
## 주요 변경 사항
## 1. redux-toolkit으로 회원가입 로직을 구현했습니다.

- ``redux-toolkit``과 비동기 처리를 위한 미들웨어인 ``redux-thunk``를 사용했습니다.
 
### 1-1. 폴더 구조
- ``redux-toolkit``을 사용하기 위해 다음과 같은 폴더와 파일을 생성했습니다.

```
redux
├── actions // 비동기 작업(ex. 서버에 요청을 보내는 작업)을 처리하는 함수를 정의합니다.
├── reducers // 액션에 따른 리듀서를 정의합니다.
└── store // 만들어진 여러 리듀서를 하나의 객체로 묶어 단일 스토어를 생성합니다.
```

### 1-2. 로직

``redux-toolkit``과 ``redux-thunk``를 사용해 회원가입 로직을 처리하는 방법은 다음과 같습니다.
- 유저가 회원가입에 필요한 정보를 입력하고 '회원가입' 버튼을 클릭합니다.
- ``redux/actions/userActions``에 정의되어 있는 비동기 함수에 입력한 정보를 ``argument``로 전달합니다.
- 해당 함수를 ``dispatch`` 함수의 ``argument``로 전달합니다.
  
```ts
// signup.tsx

 dispatch(
     // 회원가입 요청을 보내는 비동기 함수 signupAsync
      signupAsync({
        email: data.email,
        password: data.password,
        location: null,
        name: defaultName,
        profileImage: null,
      }),
    )
```
 
- 비동기 함수가 실행되고, 함수의 처리 결과에 따른 작업을 슬라이스의 ``extraReducers`` 필드에 작성합니다.

```ts
// redux/reducers/userSlice.ts

const userSlice = createSlice({
  name: 'user',
  initialState,
  reducers: {},
  // 비동기 처리 결과에 따른 작업은 여기에 작성합니다.
  extraReducers: builder => {
    builder
     // builder.addCase([비동기함수명].pending/fulfilled/rejected)
      .addCase(signupAsync.pending, state => {
        state.isSignup = false
      })
      .addCase(signupAsync.fulfilled, state => {
        state.isLoading = false
        state.isSignup = true
        alert('회원가입에 성공했습니다.')
      })
      .addCase(signupAsync.rejected, state => {
        state.isLoading = false
        alert('회원가입에 실패했습니다.')
      })
  },
})
```

## 2. axios를 사용한 요청에 기본적으로 적용할 수 있는 커스텀 axios instance를 생성했습니다.

- baseURL을 설정하여 baseURL을 입력하지 않고 필요한 endpoint만 간단하게 입력할 수 있습니다.
- ``axiosInstance.post('/signup', data)``와 같이 사용하시면 됩니다.
- 나중에 axios에 추가적인 설정이 필요하면 ``axiosInstance``에 추가하면 됩니다.

```ts
import axios from 'axios'

export const axiosInstance = axios.create({
  baseURL: process.env.APP_API,
})
```

## 3. eslint 설정을 추가했습니다.

- eslint의 ``no-param-reassign`` 설정을 해제했습니다.
## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분

- 회원가입 이후 useNavigate를 이용해 로그인 화면으로 이동하는 로직을 미처 추가하지 않았습니다.
- 일반 로그인을 구현하면서 추가하도록 하겠습니다.

## 연결된 이슈
close #9 
## 자료 (스크린샷 등)
