### PR TITLE
feat: health check controller 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/health_check/HealthCheckController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/health_check/HealthCheckController.java
@@ -1,0 +1,16 @@
+package com.twentyfour_seven.catvillage.common.health_check;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/")
+public class HealthCheckController {
+    @GetMapping
+    public ResponseEntity getHealthCheck() {
+        return new ResponseEntity<>(HttpStatus.OK);
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- Health check시 page not found 로그를 제거하기 위하여 "/"에 get 요청시 Http status OK(200)을 반환하는 컨트롤러 구현
- 로그가 너무 자주 쌓이게 되면 로그 파일의 사이즈가 너무 커지기 때문에 제거가 필요합니다!

## 코드 변경 이유
- "/"에 대한 Get 요청시 Http Status OK를 반환하는 간단한 로직 추가

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈
resolved #177

## 자료 (스크린샷 등)
