### PR TITLE
fix: 배포 action시 환경변수 생성 문제로 실패하던 문제 해결

### DIFF
--- a/.github/workflows/client-auto-deploy.yml
+++ b/.github/workflows/client-auto-deploy.yml
@@ -9,7 +9,7 @@ on:
       - "client/**"  
   push:
     branches:
-      - feat/CI-test
+      - chore/CI-test
 
 env:
   WORKING_DIRECTORY: ./client

--- a/.github/workflows/client-auto-deploy.yml
+++ b/.github/workflows/client-auto-deploy.yml
@@ -7,6 +7,9 @@ on:
     types: [closed]
     paths:
       - "client/**"  
+  push:
+    branches:
+      - feat/CI-test
 
 env:
   WORKING_DIRECTORY: ./client
@@ -48,7 +51,7 @@ jobs:
         run:  | 
           echo "PUBLIC_URL=https://${{ env.AWS_S3_BUCKET }}">>./env/.env.prod
           echo "APP_API=https://${{ env.APP_API }}">>./env/.env.prod
-  
+          cat env/.env.prod
       - name: Build
         run: npm run build
 

--- a/client/.gitignore
+++ b/client/.gitignore
@@ -13,7 +13,11 @@
 
 # misc
 .DS_Store
-/env
+
+# !env/
+/env/*
+!/env/.env.example
+
 .env.local
 .env.development.local
 .env.test.local

--- a/client/env/.env.example
+++ b/client/env/.env.example
@@ -1,0 +1,6 @@
+# 이 폴더에 .env.[name] 폴더 생성
+# ex) dev => env.dev, build => env.prod
+# [warning] .env.example은 .gitignore에 의해 무시되지 않으니 주의바랍니다.
+# .env.example를 제외한 env/ 내의 모든 파일은 .gitignore에 의해 무시됩니다.
+PUBLIC_URL=https://localhost:3000
+APP_API=https://~


### PR DESCRIPTION
## 주요 변경 사항
github action 실행시 환경변수 생성 단계에서 env폴더가 없어서 발생하던 오류를 해결하기 위해 다음을 변경하였습니다.
```
// .gitignore

/env/*
!/env/.env.example

```
env 폴더를 무시하는 것이 아닌 env폴더 내부의 파일을 무시하도록 하여 env폴더는 github에서 관리하도록 하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
기존 환경변수를 담은 파일이 계속 추적되는 문제를 해결하고자 #167 에서 env폴더를 제거하였고 더 이상 git으로 관리되지 않았습니다.

환경변수를 주입하기 위해 action파일에 아래와 같은 구문이 있었습니다.
```yml
#
# ...
  echo "PUBLIC_URL=https://${{ env.AWS_S3_BUCKET }}">>./env/.env.prod
  echo "APP_API=https://${{ env.APP_API }}">>./env/.env.prod
# ...
```
이때 env폴더가 없으므로 
`./env/.env.prod: No such file or directory`
경로 관련 문제가 발생하였습니다.
이 문제를 해결하기 위해 env폴더를 git에서 관리하도록 하여 문제를 해결하였습니다.

### 추가로 수정한 사항
- 사실 env폴더를 관리하기 위해서 `env.example`을 추가하는 것이 아닌 `.gitkeep`을 추가해도 되었지만, env.example을 추가해서 template처럼 사용할 수 있도록 하였습니다.

- chore/CI-test 브랜치에 push될때 배포 액션이 트리거 되게 추가하였습니다.
[client-auto-deploy.yml](https://github.com/codestates-seb/seb39_main_059/pull/181/files#diff-4f31bdffdfeae050984cac67d939d1190da3a8edd770f034d76e29369e97a1c9)
```yml
on:
  push:
    branches:
      - chore/CI-test
```
이는 test과정에서 직접 dev에 merge하지 않고 브랜치에서 바로바로 수정사항을 확인할 수 있게 하기 위함입니다.

## 연결된 이슈

## 자료 (스크린샷 등)
