### PR TITLE
fix: Kakao OAuth2 로그인 적용

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/CustomOAuth2UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/CustomOAuth2UserService.java
@@ -32,13 +32,17 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
 
         // OAuth2 Service ID (google, kakao, naver)
         String registrationId = userRequest.getClientRegistration().getRegistrationId();
+
         // OAuth2 로그인 진행 시 키가 되는 필드 값(PK)
         String userNameAttributeName = userRequest.getClientRegistration().getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // Test code
+//        System.out.println(oAuth2User.getAttributes().toString());
 
         // OAuth2UserService
         OAuthAttributes authAttributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
         User user = saveOfUpdate(authAttributes);
-        httpSession.setAttribute("user", new SessionUser(user));    // 직렬화된 dto 클래스 사용
+//        httpSession.setAttribute("user", new SessionUser(user));    // 직렬화된 dto 클래스 사용
 
         return new DefaultOAuth2User(
                 Collections.singleton(new SimpleGrantedAuthority(user.getRole())),

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/OAuthAttributes.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/OAuthAttributes.java
@@ -30,8 +30,9 @@ public class OAuthAttributes {
     private static OAuthAttributes ofKakao(String userNameAttributeName, Map<String, Object> attributes) {
         // kakao_account에 profile, email 정보 포함
         Map<String, Object> kakaoAccount = (Map<String, Object>)attributes.get("kakao_account");
+
         // profile에 nickname, profile_image 정보 포함
-        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("prfile");
+        Map<String, Object> kakaoProfile = (Map<String, Object>)kakaoAccount.get("profile");
 
         return OAuthAttributes.builder()
                 .name((String) kakaoProfile.get("nickname"))
@@ -46,7 +47,7 @@ public class OAuthAttributes {
         return User.builder()
                 .name(name)
                 .email(email)
-                .password(picture)
+                .profileImage(picture)
                 .build();
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.security.config;
 
+import com.twentyfour_seven.catvillage.security.CustomOAuth2UserService;
 import com.twentyfour_seven.catvillage.security.filter.JwtAccessDeniedHandler;
 import com.twentyfour_seven.catvillage.security.filter.JwtAuthenticationEntryPoint;
 import com.twentyfour_seven.catvillage.security.provider.JwtTokenizer;
@@ -23,6 +24,7 @@ public class SecurityConfig {
     private final JwtTokenizer jwtTokenizer;
     private final JwtAuthenticationEntryPoint jwtAuthenticationEntryPoint;
     private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
+    private final CustomOAuth2UserService customOAuth2UserService;
 
     @Bean
     public PasswordEncoder passwordEncoder() {
@@ -53,7 +55,12 @@ public class SecurityConfig {
                 .antMatchers("/h2/**").permitAll()
                 .anyRequest().authenticated() // 나머지 API 는 모두 인증 필요
                 .and()
-                .apply(new JwtSecurityConfig(jwtTokenizer));
+                .apply(new JwtSecurityConfig(jwtTokenizer))
+                // OAuth2.0 로그인 설정
+                .and()
+                .oauth2Login()
+                .userInfoEndpoint()
+                .userService(customOAuth2UserService);
         return http.build();
     }
 }

--- a/server/catvillage/src/main/resources-prod/application.yml
+++ b/server/catvillage/src/main/resources-prod/application.yml
@@ -25,6 +25,7 @@ spring:
           kakao:
             client-id: $KAKAO_API_KEY
             client-secret: $KAKAO_CLIENT_SECRET
+            redirect-uri: https://catvillage.tk/login/oauth2/code/kakao
 logging:
   level:
     org:

--- a/server/catvillage/src/main/resources/application-common.yml
+++ b/server/catvillage/src/main/resources/application-common.yml
@@ -12,7 +12,6 @@ spring:
         registration:
           kakao:
             client-name: Kakao
-            redirect-uri: https://catvillage.shop/login/oauth2/code/kakao
             scope: profile_nickname, profile_image, account_email
             authorization-grant-type: authorization_code
             client-authentication-method: POST


### PR DESCRIPTION
## 주요 변경 사항
- Kakao OAuth2.0 로그인 가능하도록 코드 수정 및 설정 변경
- Security config에 oauth2 로그인 설정을 함으로써 kakao oauth url에 인증 정보가 없더라도 접근이 가능하게 되었으므로 따로 설정을 하지 않고 해결
- kakao redirect-uri 설정을 `common`에서 `prod`로 변경 및 uri를 `.shop` 에서 `.tk`로 변경 (로컬 테스트시 `local`에 `redirect-uri: http:localhost:8080/login/oauth2/code/kakao` 설정 필요)

## 코드 변경 이유
- CustomOAuth2UserService class의 `loadUser()` 메서드 내 `httpSession.setAttribute()` 메서드 사용 시 에러 발생으로 인해 주석처리, 해당 메서드를 사용할 필요성이 없는 것으로 보이는데 왜 넣은 것인지 의문..
- OAuthAttributes class의 `prfile` 오타 수정 및 `toEntity()` 메서드의 `picture`를 `password`에 잘 못 할당하는 로직 수정
- SecurityConfig class에 OAuth2 인증을 위한 로직 추가

## 코드 리뷰 시 중점적으로 봐야할 부분
- CustomOAuth2UserSerivce class
- SecurityConfig class

## 연결된 이슈
resolved #16
fixed #182

## 자료 (스크린샷 등)
