### PR TITLE
feat: swagger response 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -1,18 +1,20 @@
 package com.twentyfour_seven.catvillage.board.controller;
 
-import com.twentyfour_seven.catvillage.board.dto.BoardGetResponseDto;
-import com.twentyfour_seven.catvillage.board.dto.BoardMultiGetResponse;
-import com.twentyfour_seven.catvillage.board.dto.BoardPatchDto;
-import com.twentyfour_seven.catvillage.board.dto.BoardPostDto;
+import com.twentyfour_seven.catvillage.board.dto.*;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.mapper.BoardCommentMapper;
 import com.twentyfour_seven.catvillage.board.mapper.BoardMapper;
 import com.twentyfour_seven.catvillage.board.service.BoardCommentService;
 import com.twentyfour_seven.catvillage.board.service.BoardService;
+import com.twentyfour_seven.catvillage.dto.MultiBoardResponseDto;
 import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -24,6 +26,7 @@ import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
+//@Tag(name = "Board", description = "집사생활 API")
 @RestController
 @RequestMapping("/집사생활")
 @Transactional
@@ -43,7 +46,10 @@ public class BoardController {
         this.boardCommentService = boardCommentService;
     }
 
-    @Operation(summary = "집사생활 전체 게시글 보기")
+    @Operation(summary = "집사생활 전체 게시글 보기",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "집사생활 전체 게시글 조회 성공", content = @Content(schema = @Schema(implementation = MultiBoardResponseDto.class)))
+    })
     @GetMapping
     public ResponseEntity getBoards(@RequestParam @Positive int page,
                                      @RequestParam @Positive int size) {
@@ -56,7 +62,11 @@ public class BoardController {
                 HttpStatus.OK);
     }
 
-    @Operation(summary = "집사생활 특정 게시글 보기")
+    @Operation(summary = "집사생활 특정 게시글 보기",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "집사생활 게시글 조회 성공", content = @Content(schema = @Schema(implementation = BoardGetResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글")
+    })
     @GetMapping("/{boards-id}")
     public ResponseEntity getBoard(@Positive @PathVariable("boards-id") Long boardId) {
         Board board = boardService.findBoard(boardId);
@@ -66,7 +76,11 @@ public class BoardController {
     }
 
     @Operation(summary = "집사생활 새 글 작성하기",
-            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다.")
+            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "201", description = "집사생활 게시글 등록 성공", content = @Content(schema = @Schema(implementation = BoardPostResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 정보\n존재하지 않는 태그")
+    })
     @PostMapping
     public ResponseEntity postBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                     @Valid @RequestBody BoardPostDto requestBody) {
@@ -85,7 +99,12 @@ public class BoardController {
     }
 
     @Operation(summary = "집사생활 글 수정하기",
-            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다. 처음에 글을 작성했던 유저와 로그인 되어 있는 유저가 다를 경우 405 에러가 납니다.")
+            description = "집사생활에 등록되지 않은 태그로 요청이 들어올 경우 에러가 납니다. 처음에 글을 작성했던 유저와 로그인 되어 있는 유저가 다를 경우 405 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "집사생활 게시글 수정 성공", content = @Content(schema = @Schema(implementation = BoardPostResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 정보\n존재하지 않는 게시글"),
+            @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
+    })
     @PatchMapping("/{boards-id}")
     public ResponseEntity patchBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                      @Positive @PathVariable("boards-id") Long boardId,
@@ -100,7 +119,12 @@ public class BoardController {
     }
 
     @Operation(summary = "집사생활 글 삭제하기",
-    description = "존재하지 않는 글의 식별자가 들어올 경우 에러가 납니다. 글 작성자가 아닌 다른 유저가 제거를 요청하면 405 에러가 납니다.")
+    description = "존재하지 않는 글의 식별자가 들어올 경우 에러가 납니다. 글 작성자가 아닌 다른 유저가 제거를 요청하면 405 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "204", description = "집사생활 게시글 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+            @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
+    })
     @DeleteMapping("/{board-id}")
     public ResponseEntity deleteBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                       @Positive @PathVariable("board-id") Long boardId)

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -9,6 +9,10 @@ import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -21,6 +25,7 @@ import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 import java.util.List;
 
+//@Tag(name = "Cat", description = "고양이 API")
 @RestController
 @RequestMapping("/cats")
 @Transactional
@@ -38,7 +43,11 @@ public class CatController {
     }
 
     @Operation(summary = "고양이 등록하기",
-            description = "로그인한 유저 정보를 꺼내와서 유저에 고양이를 추가합니다. 만약 등록되지 않은 유저일 경우 404 에러가 납니다.")
+            description = "로그인한 유저 정보를 꺼내와서 유저에 고양이를 추가합니다. 만약 등록되지 않은 유저일 경우 404 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "201", description = "고양이 등록 성공", content = @Content(schema = @Schema(implementation = CatResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저")
+    })
     @PostMapping
     public ResponseEntity postCat(@Valid @RequestBody CatPostDto catPostDto,
                                   @AuthenticationPrincipal User user) {
@@ -52,7 +61,11 @@ public class CatController {
     }
 
     @Operation(summary = "고양이 프로필 정보 불러오기",
-            description = "로그인 하지 않은 유저도 요청 가능합니다." )
+            description = "로그인 하지 않은 유저도 요청 가능합니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "고양이 프로필 조회 성공", content = @Content(schema = @Schema(implementation = CatResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 프로필")
+    })
     @GetMapping("/{cats-id}")
     public ResponseEntity getCat(@PathVariable("cats-id") @Positive long catId) {
         Cat cat = catService.findCat(catId);
@@ -64,7 +77,12 @@ public class CatController {
     }
 
     @Operation(summary = "고양이 프로필 수정하기",
-            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.")
+            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "고양이 프로필 수정 성공", content = @Content(schema = @Schema(implementation = CatResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 프로필"),
+            @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
+    })
     @PatchMapping("/{cats-id}")
     public ResponseEntity patchCat(@PathVariable("cats-id") @Positive long catId,
                                    @Valid @RequestBody CatPostDto catPostDto,
@@ -77,7 +95,11 @@ public class CatController {
     }
 
     @Operation(summary = "고양이 프로필 삭제하기",
-            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.")
+            description = "로그인된 유저 정보와 처음 고양이를 등록했던 유저 정보가 일치하지 않을 경우 405 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "204", description = "고양이 프로필 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 프로필")
+    })
     @DeleteMapping("/{cats-id}")
     public ResponseEntity deleteCat(@PathVariable("cats-id") @Positive long catId) {
         catService.removeCat(catId);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/health_check/HealthCheckController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/health_check/HealthCheckController.java
@@ -1,14 +1,20 @@
 package com.twentyfour_seven.catvillage.common.health_check;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+//@Tag(name = "HealthCheck", description = "서버 헬스체크 API")
 @RestController
 @RequestMapping("/")
 public class HealthCheckController {
+    @Operation(summary = "헬스 체크용 API", description = "헬스 체크를 위한 용도")
+    @ApiResponse(responseCode = "200", description = "통신 성공")
     @GetMapping
     public ResponseEntity getHealthCheck() {
         return new ResponseEntity<>(HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
@@ -1,6 +1,11 @@
 package com.twentyfour_seven.catvillage.common.picture.controller;
 
 import com.twentyfour_seven.catvillage.common.picture.service.S3UploadService;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -11,11 +16,16 @@ import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 
+//@Tag(name = "Upload", description = "파일 업로드 API")
 @RequiredArgsConstructor
 @RestController
 public class FileUploadController {
     private final S3UploadService s3UploadService;
 
+    @Operation(summary = "이미지 업로드", description = "이미지를 업로드 합니다",
+    responses = {
+            @ApiResponse(responseCode = "201", description = "이미지 업로드 성공", content = @Content(schema = @Schema(implementation = String.class, description = "이미지 저장 경로(URL)")))
+    })
     @PostMapping("/upload")
     public ResponseEntity uploadFile(@RequestParam("images") MultipartFile multipartFile) throws IOException {
         return new ResponseEntity<>(s3UploadService.upload(multipartFile), HttpStatus.CREATED);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -1,5 +1,22 @@
 package com.twentyfour_seven.catvillage.config;
 
+import com.fasterxml.classmate.TypeResolver;
+import com.twentyfour_seven.catvillage.board.dto.BoardGetResponseDto;
+import com.twentyfour_seven.catvillage.board.dto.BoardMultiGetResponse;
+import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
+import com.twentyfour_seven.catvillage.board.dto.BoardUserCommentResponseDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
+import com.twentyfour_seven.catvillage.dto.MultiBoardResponseDto;
+import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedGetResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedMultiGetResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedMultiResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.FeedResponseDto;
+import com.twentyfour_seven.catvillage.security.dto.TokenDto;
+import com.twentyfour_seven.catvillage.user.dto.UserGetResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.UserPatchResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.UserPostResponseDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
@@ -20,12 +37,15 @@ Swagger Rest API 문서 자동 생성을 위한 설정 클래스 입니다.
  */
 
 @Configuration
-@EnableSwagger2
+// Swagger v3에서는 아래의 어노테이션을 사용하지 않는 것을 권장
+//@EnableSwagger2
 @EnableWebMvc
 public class SwaggerConfig {
 
     @Bean
     public Docket swagger() {
+
+        TypeResolver typeResolver = new TypeResolver();
 
         Parameter parameterBuilder = new ParameterBuilder()
                 .name(HttpHeaders.AUTHORIZATION)
@@ -36,7 +56,26 @@ public class SwaggerConfig {
                 .build();
 
         return new Docket(DocumentationType.SWAGGER_2)
-                .useDefaultResponseMessages(true)
+                .additionalModels(
+                        typeResolver.resolve(UserPostResponseDto.class),
+                        typeResolver.resolve(UserPatchResponseDto.class),
+                        typeResolver.resolve(UserGetResponseDto.class),
+                        typeResolver.resolve(TokenDto.class),
+                        typeResolver.resolve(FeedResponseDto.class),
+                        typeResolver.resolve(FeedGetResponseDto.class),
+                        typeResolver.resolve(FeedMultiGetResponseDto.class),
+                        typeResolver.resolve(FeedMultiResponseDto.class),
+                        typeResolver.resolve(MultiResponseDto.class),
+                        typeResolver.resolve(CatResponseDto.class),
+                        typeResolver.resolve(CatTagResponseDto.class),
+                        typeResolver.resolve(BoardGetResponseDto.class),
+                        typeResolver.resolve(BoardMultiGetResponse.class),
+                        typeResolver.resolve(BoardPostResponseDto.class),
+                        typeResolver.resolve(BoardUserCommentResponseDto.class),
+                        typeResolver.resolve(MultiBoardResponseDto.class)
+                )
+//                .useDefaultResponseMessages(true)
+                .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())
                 .select()
                 .apis(RequestHandlerSelectors.any())

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/dto/MultiBoardResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/dto/MultiBoardResponseDto.java
@@ -1,0 +1,13 @@
+package com.twentyfour_seven.catvillage.dto;
+
+import com.twentyfour_seven.catvillage.board.dto.BoardMultiGetResponse;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+// 해당 클래스는 Swagger에서 반환 class로 사용하기 위해 만든 클래스
+public class MultiBoardResponseDto extends MultiResponseDto<BoardMultiGetResponse>{
+    public MultiBoardResponseDto(List<BoardMultiGetResponse> items, Page pageInfo) {
+        super(items, pageInfo);
+    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -7,12 +7,12 @@ public enum ExceptionCode {
     MEMBER_EMAIL_EXISTS(409, "Email address already in use"),
     MEMBER_NAME_EXISTS(409, "Name already in use"),
     BREED_NOT_FOUND(404, "Breed not found"),
-    CAT_NOT_FOUND(409, "Cat not found"),
-    PICTURE_NOT_FOUND(409, "Picture not found"),
-    BOARD_NOT_FOUND(409, "Board not found"),
-    BOARD_TAG_NOT_FOUND(409, "Board tag not found"),
+    CAT_NOT_FOUND(404, "Cat not found"),
+    PICTURE_NOT_FOUND(404, "Picture not found"),
+    BOARD_NOT_FOUND(404, "Board not found"),
+    BOARD_TAG_NOT_FOUND(404, "Board tag not found"),
     INVALID_USER(405, "Method not allowed"),
-    FEED_NOT_FOUND(409, "Feed not found");
+    FEED_NOT_FOUND(404, "Feed not found");
 
     @Getter
     private final int status;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -12,6 +12,10 @@ import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
 import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,6 +30,7 @@ import javax.validation.constraints.Positive;
 import java.util.List;
 import java.util.stream.Collectors;
 
+//@Tag(name = "Feed", description = "냥이생활 API")
 @RestController
 @RequestMapping("/냥이생활")
 @Transactional
@@ -51,7 +56,11 @@ public class FeedController {
         this.feedCommentMapper = feedCommentMapper;
     }
 
-    @Operation(summary = "냥이생활 피드 작성하기")
+    @Operation(summary = "냥이생활 피드 작성하기",
+    responses = {
+            @ApiResponse(responseCode = "201", description = "냥이생활 피드 등록 성공", content = @Content(schema = @Schema(implementation = FeedResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 정보")
+    })
     @PostMapping
     public ResponseEntity postFeed(@RequestBody @Valid FeedPostDto feedPostDto) {
         Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);
@@ -61,7 +70,11 @@ public class FeedController {
         return new ResponseEntity<>(feedMapper.feedToFeedResponseDto(createFeed), HttpStatus.CREATED);
     }
 
-    @Operation(summary = "냥이생활 특정 피드 보기")
+    @Operation(summary = "냥이생활 특정 피드 보기",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "냥이생활 피드 정보 조회 성공", content = @Content(schema = @Schema(implementation = FeedGetResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 냥이생활 피드")
+    })
     @GetMapping("/{feeds-id}")
     public ResponseEntity getFeed(@PathVariable("feeds-id") @Positive long feedId) {
         Feed feed = feedService.findFeed(feedId);
@@ -73,7 +86,10 @@ public class FeedController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation(summary = "냥이생활 전체 게시글 보기")
+    @Operation(summary = "냥이생활 전체 게시글 보기",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "전체 냥이생활 피드 조회 성공", content = @Content(schema = @Schema(implementation = FeedMultiResponseDto.class)))
+    })
     @GetMapping
     public ResponseEntity getFeeds(@RequestParam @Positive int page,
                                    @RequestParam @Positive int size,
@@ -100,7 +116,12 @@ public class FeedController {
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
-    @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.")
+    @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "냥이생활 피드 수정 성공", content = @Content(schema = @Schema(implementation = FeedResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저"),
+            @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
+    })
     @PatchMapping("{feeds-id}")
     public ResponseEntity patchFeed(@PathVariable("feeds-id") @Positive long feedId,
                                     @RequestBody @Valid FeedPostDto feedPostDto,

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -119,7 +119,7 @@ public class FeedController {
     @Operation(summary = "냥이생활 작성한 글 수정하기", description = "로그인한 유저와 글을 작성했던 유저가 다르면 에러가 납니다.",
     responses = {
             @ApiResponse(responseCode = "200", description = "냥이생활 피드 수정 성공", content = @Content(schema = @Schema(implementation = FeedResponseDto.class))),
-            @ApiResponse(responseCode = "404", description = "존재하지 않는 유저"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 피드"),
             @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
     })
     @PatchMapping("{feeds-id}")

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
@@ -7,37 +7,53 @@ import com.twentyfour_seven.catvillage.security.dto.UserRequestDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostResponseDto;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import javax.transaction.Transactional;
 
+//@Tag(name = "Auth", description = "인증 API")
 @RestController
 @RequiredArgsConstructor
 @Transactional
 public class AuthController {
     private final AuthService authService;
 
-    @Operation(summary = "회원가입", description = "이미 가입되어 있는 이메일일 경우 에러가 납니다.")
+    @Operation(summary = "회원가입", description = "이미 가입되어 있는 이메일일 경우 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "201", description = "회원가입 성공", content = @Content(schema = @Schema(implementation = UserPostResponseDto.class))),
+            @ApiResponse(responseCode = "409", description = "이미 존재하는 이메일")
+    })
     @PostMapping("/signup")
     public ResponseEntity signup(@RequestBody UserPostDto userPostDto) {
         return new ResponseEntity<>(authService.signup(userPostDto), HttpStatus.CREATED);
     }
 
     @Operation(summary = "로그인",
-            description = "등록되어 있지 않은 유저일 경우 에러가 납니다.")
+            description = "등록되어 있지 않은 유저일 경우 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "로그인 성공", content = @Content(schema = @Schema(implementation = TokenDto.class))),
+            @ApiResponse(responseCode = "400", description = "인증 실패")
+    })
     @PostMapping("/login")
     public ResponseEntity login(@RequestBody UserRequestDto userRequestDto) {
         return new ResponseEntity<>(authService.login(userRequestDto), HttpStatus.OK);
     }
 
     @Operation(summary = "JWT 토큰 재발급",
-            description = "엑세스 토큰의 기간이 만료된 경우 해당 요청으로 엑세스 토큰 + 리프레시 토큰을 새로 발급받을 수 있습니다.")
+            description = "엑세스 토큰의 기간이 만료된 경우 해당 요청으로 엑세스 토큰 + 리프레시 토큰을 새로 발급받을 수 있습니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "토큰 재발급 성공", content = @Content(schema = @Schema(implementation = TokenDto.class))),
+            @ApiResponse(responseCode = "400", description = "토근 재발급 실패")
+    })
     @PostMapping("/reissue")
     public ResponseEntity reissue(@RequestBody TokenRequestDto tokenRequestDto) {
         return new ResponseEntity<>(authService.reissue(tokenRequestDto), HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -1,12 +1,17 @@
 package com.twentyfour_seven.catvillage.user.controller;
 
 import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.UserGetResponseDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPatchDto;
-import com.twentyfour_seven.catvillage.user.dto.UserPostDto;
+import com.twentyfour_seven.catvillage.user.dto.UserPatchResponseDto;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.mapper.UserMapper;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -17,6 +22,7 @@ import javax.transaction.Transactional;
 import javax.validation.Valid;
 import javax.validation.constraints.Positive;
 
+//@Tag(name = "Users", description = "유저 API")
 @RestController
 @RequestMapping("/users")
 @Transactional
@@ -38,7 +44,11 @@ public class UserController {
 //    }
 
     @Operation(summary = "유저 이름(displayName) 중복 검사",
-            description = "이미 등록되어 있는 이름일 경우 409 에러가 납니다.")
+            description = "이미 등록되어 있는 이름일 경우 409 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "사용 가능한 이름"),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 이름")
+    })
     @GetMapping("/names")
     public ResponseEntity getNameCheck(@RequestParam String name) {
         userService.nameDuplicateCheck(name);
@@ -46,7 +56,10 @@ public class UserController {
     }
 
     @Operation(summary = "유저 정보 가져오기(pagination)",
-            description = "등록되어 있는 모든 유저 정보를 페이지화하여 반환합니다. 로그인되지 않은 사용자도 요청 가능합니다.")
+            description = "등록되어 있는 모든 유저 정보를 페이지화하여 반환합니다. 로그인되지 않은 사용자도 요청 가능합니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "전체 유저 정보 조회 성공")
+    })
     @GetMapping
     public ResponseEntity getUsers(@RequestParam @Positive int page,
                                    @RequestParam @Positive int size) {
@@ -62,7 +75,11 @@ public class UserController {
     }
 
     @Operation(summary = "유저 정보 불러오기",
-            description = "로그인되지 않은 사용자도 요청 가능합니다.")
+            description = "로그인되지 않은 사용자도 요청 가능합니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "유저 정보 조회 성공", content = @Content(schema = @Schema(implementation = UserGetResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.")
+    })
     @GetMapping("/{user-id}")
     public ResponseEntity getUser(@PathVariable("user-id") Long userId) {
         User findUser = userService.findUser(userId);
@@ -70,7 +87,12 @@ public class UserController {
     }
 
     @Operation(summary = "유저 정보 변경",
-            description = "로그인된 유저가 정보를 변경하려는 유저와 다른 경우 405 에러가 납니다.")
+            description = "로그인된 유저가 정보를 변경하려는 유저와 다른 경우 405 에러가 납니다.",
+    responses = {
+            @ApiResponse(responseCode = "200", description = "유저 정보 수정 성공", content = @Content(schema = @Schema(implementation = UserPatchResponseDto.class))),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다."),
+            @ApiResponse(responseCode = "409", description = "이미 사용 중인 이름")
+    })
     @PatchMapping("/{user-id}")
     public ResponseEntity patchUser(@PathVariable("user-id") Long userId,
                                     @Valid @RequestBody UserPatchDto requestBody) {
@@ -80,7 +102,11 @@ public class UserController {
     }
 
     @Operation(summary = "유저 탈퇴",
-            description = "유저 정보가 바로 삭제되지 않고 7일동안 유지된 후 삭제됩니다. 그 이전에는 복구 가능합니다.")
+            description = "유저 정보가 바로 삭제되지 않고 7일동안 유지된 후 삭제됩니다. 그 이전에는 복구 가능합니다.",
+    responses = {
+            @ApiResponse(responseCode = "204", description = "유저 탈퇴 성공"),
+            @ApiResponse(responseCode = "404", description = "해당 유저를 찾을 수 없습니다.")
+    })
     @DeleteMapping("/{user-id}/delete") // TODO : Security 적용 이후 "/delete"로 경로 변경 의논 필요
     public ResponseEntity deleteUser(@PathVariable("user-id") Long userId) {
         userService.removeUser(userId);


### PR DESCRIPTION
## 주요 변경 사항
- swagger response data 추가
- EnableSwagger2 어노테이션 주석 처리
- Tag는 그룹화가 안되어 추가 했다가 주석 처리

## 코드 변경 이유
- MultiBoardResponseDto class는 Swagger로 response를 정의할 때 class로 추가하기 때문에 swagger의 response class 지정을 위해 구현
- `@EnableSwagger2` 해당 어노테이션은 Swagger v3을 사용하는 경우에는 사용을 권장하지 않기에 주석 처리
- 정의한 response 데이터만 보이도록 하기 위하여 `useDefaultResponeMessages()`의 값을 `false`로 변경
- `@Tag` 어노테이션을 사용하여 컨트롤러 별 그룹화를 시도하였으나 정상적으로 동작하지 않아 일단 주석 처리
- `@ApiResponse` 어노테이션 사용 시 동일한 resposneCode를 사용하는 경우 최초 정의한 내용만 담기기 때문에 하나의 decription에 여러 내용을 작성

## 코드 리뷰 시 중점적으로 봐야할 부분
- 각 컨트롤러의 메서드들의 `@ApiResponse()`
- SwaggerConfig class

## 연결된 이슈
resolved #186

## 자료 (스크린샷 등)
