### PR TITLE
feat: 냥이생활 글 삭제하기 기능 구현 및 고양이 삭제시 유저 검증 로직 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -101,8 +101,9 @@ public class CatController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 프로필")
     })
     @DeleteMapping("/{cats-id}")
-    public ResponseEntity deleteCat(@PathVariable("cats-id") @Positive long catId) {
-        catService.removeCat(catId);
+    public ResponseEntity deleteCat(@PathVariable("cats-id") @Positive long catId,
+                                    @AuthenticationPrincipal User user) {
+        catService.removeCat(catId, user.getUsername());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -48,7 +48,14 @@ public class CatService {
         return findCat;
     }
 
-    public void removeCat(long catId) {
+    public void removeCat(long catId, String email) {
+        // 요청을 보낸 유저가 적절한지 검증
+        userService.findVerifiedEmail(email);
+        String userEmail = findVerifiedCat(catId).getUser().getEmail();
+        if (email.equals(userEmail)) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+
         Cat findCat = findVerifiedCat(catId);
         catRepository.delete(findCat);
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -122,7 +122,7 @@ public class FeedController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 피드"),
             @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
     })
-    @PatchMapping("{feeds-id}")
+    @PatchMapping("/{feeds-id}")
     public ResponseEntity patchFeed(@PathVariable("feeds-id") @Positive long feedId,
                                     @RequestBody @Valid FeedPostDto feedPostDto,
                                     @AuthenticationPrincipal User user) {
@@ -140,6 +140,20 @@ public class FeedController {
         FeedResponseDto response = feedMapper.feedToFeedResponseDto(updateFeed);
         response.setTags(feedTagMapper.feedTagsToFeedTagDtos(updateTags));
         return new ResponseEntity<>(HttpStatus.OK);
+    }
+
+    @Operation(summary = "냥이생활 작성한 글 삭제하기", description = "로그인한 유저와 글을 작성한 유저가 다를 경우: 405에러, 글이 존재하지 않을 경우: 409",
+    responses = {
+            @ApiResponse(responseCode = "204", description = "냥이생활 피드 삭제 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 게시글"),
+            @ApiResponse(responseCode = "405", description = "유저 정보 불일치")
+    })
+    @DeleteMapping("/{feeds-id}")
+    public ResponseEntity deleteFeed(@PathVariable("feeds-id") @Positive long feedId,
+                                     @AuthenticationPrincipal User user) {
+        // 이메일과 feedId 서비스에 전달
+        feedService.removeFeed(feedId, user.getUsername());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -131,4 +131,14 @@ public class FeedService {
         );
         return feedRepository.save(updateFeed);
     }
+    
+    public void removeFeed(long feedId, String email) {
+        Feed findFeed = findVerifiedFeed(feedId);
+        User findUser = userService.findVerifiedEmail(email);
+        // feed에 저장된 유저와 요청을 보낸 유저가 다르면 INVALID_USER Exception throw
+        if (!findFeed.getCat().getUser().getUserId().equals(findUser.getUserId())) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+        feedRepository.delete(findFeed);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -131,7 +131,7 @@ public class FeedService {
         );
         return feedRepository.save(updateFeed);
     }
-    
+
     public void removeFeed(long feedId, String email) {
         Feed findFeed = findVerifiedFeed(feedId);
         User findUser = userService.findVerifiedEmail(email);


### PR DESCRIPTION
## 주요 변경 사항
- FeedController에 deleteFeed 구현 (로그인 정보에서 username을 가져와서 서비스에 같이 전달합니다.)
- FeedController에 patchFeed mapping 경로에 / 빠져서 추가
- FeedServiced에 removeFeed 구현 (유저 이메일로 글을 작성한 유저의 이메일과 같은지 검증, 해당 게시글이 존재하는지 확인)
- delete-cat 로직에 유저 검증하는 로직 추가

## 코드 변경 이유
- 냥이생활 글 삭제하기는 해당 글을 작성한 유저만 보낼 수 있는 요청이기 때문에 올바른 유저인지 확인하도록 구현하였습니다.
- 고양이 삭제하는 로직에 로그인한 유저 정보를 바탕으로 유저를 검증하는 로직이 빠져있어서 추가하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatController, CatService의 유저 검증 로직 추가한 부분
- FeedService에 removeFeed 메서드

## 연결된 이슈
- close #97 

## 자료 (스크린샷 등)
