### PR TITLE
fix: 냥이생활 피드 작성하기 및 수정하기 기능 bug fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/entity/Picture.java
@@ -33,7 +33,6 @@ public class Picture {
     private String path;
 
     @Builder
-
     public Picture(Long pictureId, Feed feed, Board board, String path) {
         this.pictureId = pictureId;
         this.feed = feed;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -67,7 +67,9 @@ public class FeedController {
         Feed createFeed = feedService.createFeed(feed, feedPostDto.getCatId());
         List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());
         List<FeedTag> createFeedTags = feedTagService.createTags(createFeed, feedTags);
-        return new ResponseEntity<>(feedMapper.feedToFeedResponseDto(createFeed), HttpStatus.CREATED);
+        FeedResponseDto feedResponseDto = feedMapper.feedToFeedResponseDto(createFeed);
+        feedResponseDto.setTags(feedTagMapper.feedTagsToFeedTagDtos(createFeedTags));
+        return new ResponseEntity<>(feedResponseDto, HttpStatus.CREATED);
     }
 
     @Operation(summary = "냥이생활 특정 피드 보기",
@@ -139,7 +141,7 @@ public class FeedController {
         // responseDto 생성하여 값 대입
         FeedResponseDto response = feedMapper.feedToFeedResponseDto(updateFeed);
         response.setTags(feedTagMapper.feedTagsToFeedTagDtos(updateTags));
-        return new ResponseEntity<>(HttpStatus.OK);
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @Operation(summary = "냥이생활 작성한 글 삭제하기", description = "로그인한 유저와 글을 작성한 유저가 다를 경우: 405에러, 글이 존재하지 않을 경우: 409",

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -62,11 +62,14 @@ public class FeedController {
             @ApiResponse(responseCode = "404", description = "존재하지 않는 고양이 정보")
     })
     @PostMapping
-    public ResponseEntity postFeed(@RequestBody @Valid FeedPostDto feedPostDto) {
+    public ResponseEntity postFeed(@RequestBody @Valid FeedPostDto feedPostDto,
+                                   @AuthenticationPrincipal User user) {
         Feed feed = feedMapper.feedPostDtoToFeed(feedPostDto);
-        Feed createFeed = feedService.createFeed(feed, feedPostDto.getCatId());
+        Feed createFeed = feedService.createFeed(feed, feedPostDto.getCatId(), user.getUsername());
+
         List<FeedTag> feedTags = feedTagMapper.feedTagDtosToFeedTags(feedPostDto.getTags());
         List<FeedTag> createFeedTags = feedTagService.createTags(createFeed, feedTags);
+
         FeedResponseDto feedResponseDto = feedMapper.feedToFeedResponseDto(createFeed);
         feedResponseDto.setTags(feedTagMapper.feedTagsToFeedTagDtos(createFeedTags));
         return new ResponseEntity<>(feedResponseDto, HttpStatus.CREATED);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
@@ -56,6 +56,7 @@ public class Feed extends DateTable {
 //    private List<Like> likes = new ArrayList<>();
 
     public Feed(String body) {
+        pictures = new ArrayList<>();
         this.body = body;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/Feed.java
@@ -56,7 +56,6 @@ public class Feed extends DateTable {
 //    private List<Like> likes = new ArrayList<>();
 
     public Feed(String body) {
-        pictures = new ArrayList<>();
         this.body = body;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -37,9 +37,11 @@ public interface FeedMapper {
             return null;
         }
         Feed feed = new Feed(feedPostDto.getBody());
-        feedPostDto.getPictures().forEach(
-                pictureDto -> feed.getPictures().add(Picture.builder().path(pictureDto.getPicture()).build())
-        );
+        if (feedPostDto.getPictures() != null) {
+            feedPostDto.getPictures().forEach(
+                    pictureDto -> feed.getPictures().add(Picture.builder().path(pictureDto.getPicture()).build())
+            );
+        }
         return feed;
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -60,9 +60,12 @@ public interface FeedMapper {
     List<FeedGetResponseDto> feedsToFeedGetResponseDtos(List<Feed> feeds);
 
     default FeedMultiGetResponseDto feedToFeedMultiGetResponseDto(Feed feed) {
-        return new FeedMultiGetResponseDto(
-                feed.getFeedId(),
-                feed.getPictures().get(0).getPath());
+        FeedMultiGetResponseDto feedMultiGetResponseDto =  new FeedMultiGetResponseDto();
+        feedMultiGetResponseDto.setFeedId(feed.getFeedId());
+        if(!feed.getPictures().isEmpty()) {
+            feedMultiGetResponseDto.setImage(feed.getPictures().get(0).getPath());
+        }
+        return feedMultiGetResponseDto;
     }
     List<FeedMultiGetResponseDto> feedsToFeedMultiGetResponseDtos(List<Feed> feeds);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -66,8 +66,6 @@ public class FeedService {
 
         // feed 저장 후 반환
         Feed saveFeed = feedRepository.save(feed);
-        saveFeed.getPictures();
-
         return saveFeed;
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -42,14 +42,33 @@ public class FeedService {
         this.followService = followService;
     }
 
-    public Feed createFeed(Feed feed, long catId) {
+    public Feed createFeed(Feed feed, long catId, String email) {
+        // 작성한 고양이 프로필이 유효한지 확인
         Cat findCat = catService.findVerifiedCat(catId);
+
+        // 로그인한 유저의 고양이가 아닐경우 에러
+        if (!findCat.getUser().getEmail().equals(email)) {
+            throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+
+        // feed에 고양이 정보 저장
         feed.setCat(findCat);
+
+        // Picture 저장
         feed.getPictures().forEach(
-                picture -> pictureService.createPicture(picture)
+                picture ->
+                    pictureService.createPicture(
+                            Picture.builder()
+                                    .path(picture.getPath())
+                                    .feed(feed)
+                                    .build())
         );
 
-        return feedRepository.save(feed);
+        // feed 저장 후 반환
+        Feed saveFeed = feedRepository.save(feed);
+        saveFeed.getPictures();
+
+        return saveFeed;
     }
 
     public Feed findFeed(long feedId) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
@@ -24,11 +24,16 @@ public class FeedTagService {
     }
 
     public List<FeedTag> createTags(Feed feed, List<FeedTag> feedTags) {
+        if (feedTags.isEmpty()) {
+            return null;
+        }
+        List<FeedTag> saveFeedTags = new ArrayList<>();
         feedTags.forEach(feedTag -> {
             FeedTag createFeedTag = createTag(feedTag);
             createTagToFeed(new TagToFeed(feed, createFeedTag));
+            saveFeedTags.add(createFeedTag);
         });
-        return feedTags;
+        return saveFeedTags;
     }
 
     public FeedTag createTag(FeedTag feedTag) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
@@ -32,7 +32,8 @@ public class FeedTagService {
     }
 
     public FeedTag createTag(FeedTag feedTag) {
-        return feedTagRepository.save(feedTag);
+        Optional<FeedTag> optionalFeedTag = feedTagRepository.findByTagName(feedTag.getTagName());
+        return optionalFeedTag.orElse(feedTagRepository.save(feedTag));
     }
 
     public TagToFeed createTagToFeed(TagToFeed tagToFeed) {


### PR DESCRIPTION
## 주요 변경 사항
- get-feed에 feed 마다 이미지 list 길이 확인하여 1개라도 있을 경우에만 가져오도록 수정
- createFeed 에 요청한 user 검증 로직 추가
- createFeed에서 pictureService의 createPicture 요청 시 picture에 feed 저장하여 파라미터로 전달
- FeedTagService createTags에 feedTag 리스트 생성하여 값 담아 전달
- FeedMapper에 pictures 가 null 이 아닐 경우만 picture 리스트 저장하도록 변경

## 코드 변경 이유
- 요청시 이미지 list 길이 확인 없이 첫번째 인덱스(0번) 가져오려고 해서 이미지 없을 시 ArrayOutOfIndex 오류가 발생할 수 있어 연결된 Picture가 1개라도 있는지 확인하도록 수정하였습니다.
- 냥이생활 피드 요청시 로그인한 유저가 요청으로 보낸 catId를 소유한 유저인지 검증하는 로직이 없어서 추가하였습니다.
- 냥이생활 피드작성하기와 수정하기 기능에 DB에 잘못 저장되거나 응답이 에러로 와서 수정하여 해결했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 테스트 진행하면서 문제없는지 확인 필요

## 연결된 이슈
close #185 

## 자료 (스크린샷 등)
