### PR TITLE
fix: Swagger API docs에 UserMyInfoDto 적용 안되는 문제 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -15,6 +15,7 @@ import com.twentyfour_seven.catvillage.feed.dto.FeedMultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.FeedResponseDto;
 import com.twentyfour_seven.catvillage.security.dto.TokenDto;
 import com.twentyfour_seven.catvillage.user.dto.UserGetResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.UserMyInfoDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPatchResponseDto;
 import com.twentyfour_seven.catvillage.user.dto.UserPostResponseDto;
 import org.springframework.context.annotation.Bean;
@@ -72,7 +73,8 @@ public class SwaggerConfig {
                         typeResolver.resolve(BoardMultiGetResponse.class),
                         typeResolver.resolve(BoardPostResponseDto.class),
                         typeResolver.resolve(BoardUserCommentResponseDto.class),
-                        typeResolver.resolve(MultiBoardResponseDto.class)
+                        typeResolver.resolve(MultiBoardResponseDto.class),
+                        typeResolver.resolve(UserMyInfoDto.class)
                 )
 //                .useDefaultResponseMessages(true)
                 .useDefaultResponseMessages(false)


### PR DESCRIPTION
## 주요 변경 사항
SwaggerConfig 클래스에 additionalModels에 UserMyInfoDto 적용

## 코드 변경 이유
Swagger API Docs 페이지에서 /users/my-info 요청에 관한 body 정보가 없어 SwaggerConfig에 코드 추가했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈

## 자료 (스크린샷 등)
