### PR TITLE
fix: 고양이 등록하기, 수정하기 및 유저 정보 수정하기 기능 오류 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -97,7 +97,7 @@ public class CatController {
         String breed = catPostDto.getBreed();
         List<CatTag> catTags = catTagMapper.catTagPostDtosToCatTags(catPostDto.getTags());
 
-        Cat updateCat = catService.updateCat(cat, breed, user.getUsername());
+        Cat updateCat = catService.updateCat(catId, cat, breed, user.getUsername());
         List<CatTag> updateTag = catTagService.updateTag(catTags, updateCat);
 
         CatResponseDto response = catMapper.catToCatResponseDto(updateCat);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -8,6 +8,7 @@ import com.twentyfour_seven.catvillage.cat.entity.CatTag;
 import com.twentyfour_seven.catvillage.cat.mapper.CatMapper;
 import com.twentyfour_seven.catvillage.cat.mapper.CatTagMapper;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import com.twentyfour_seven.catvillage.cat.service.CatTagService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -34,12 +35,14 @@ public class CatController {
     private final CatService catService;
     private final CatMapper catMapper;
     private final CatTagMapper catTagMapper;
+    private final CatTagService catTagService;
 
     public CatController(CatService catService, CatMapper catMapper,
-                         CatTagMapper catTagMapper) {
+                         CatTagMapper catTagMapper, CatTagService catTagService) {
         this.catService = catService;
         this.catMapper = catMapper;
         this.catTagMapper = catTagMapper;
+        this.catTagService = catTagService;
     }
 
     @Operation(summary = "고양이 등록하기",
@@ -54,10 +57,13 @@ public class CatController {
         Cat cat = catMapper.catPostDtoToCat(catPostDto);
         String breed = catPostDto.getBreed();
         List<CatTag> catTags = catTagMapper.catTagPostDtosToCatTags(catPostDto.getTags());
-        Cat createCat = catService.createCat(cat, breed, catTags, user.getUsername());
-        CatResponseDto catResponseDto = catMapper.catToCatResponseDto(createCat);
-        catResponseDto.setTags(catTagMapper.tagToCatsToCatTagResponseDtos(createCat.getTagToCats()));
-        return new ResponseEntity<>(catResponseDto, HttpStatus.CREATED);
+
+        Cat createCat = catService.createCat(cat, breed, user.getUsername());
+        List<CatTag> createCatTags = catTagService.saveTag(catTags, createCat);
+
+        CatResponseDto response = catMapper.catToCatResponseDto(createCat);
+        response.setTags(catTagMapper.catTagsToCatTagResponseDtos(createCatTags));
+        return new ResponseEntity<>(response, HttpStatus.CREATED);
     }
 
     @Operation(summary = "고양이 프로필 정보 불러오기",
@@ -90,8 +96,13 @@ public class CatController {
         Cat cat = catMapper.catPostDtoToCat(catPostDto);
         String breed = catPostDto.getBreed();
         List<CatTag> catTags = catTagMapper.catTagPostDtosToCatTags(catPostDto.getTags());
-        Cat saveCat = catService.updateCat(cat, breed, catTags, user.getUsername());
-        return new ResponseEntity<>(catMapper.catToCatResponseDto(saveCat), HttpStatus.OK);
+
+        Cat updateCat = catService.updateCat(cat, breed, user.getUsername());
+        List<CatTag> updateTag = catTagService.updateTag(catTags, updateCat);
+
+        CatResponseDto response = catMapper.catToCatResponseDto(updateCat);
+        response.setTags(catTagMapper.catTagsToCatTagResponseDtos(updateTag));
+        return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
     @Operation(summary = "고양이 프로필 삭제하기",

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
@@ -24,21 +24,27 @@ public class Cat {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long catId;
 
+    @Setter
     @Column(name = "NAME", length = 16, nullable = false)
     private String name;
 
+    @Setter
     @Column(name = "BIRTH_DATE")
     private LocalDateTime birthDate;
 
+    @Setter
     @Column(name = "SEX", length = 1)
     private String sex;
 
+    @Setter
     @Column(name = "WEIGHT")
     private int weight;
 
+    @Setter
     @Column(name = "IMAGE", length = 500)
     private String image;
 
+    @Setter
     @Column(name = "BODY", length = 1000)
     private String body;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/Cat.java
@@ -68,11 +68,12 @@ public class Cat {
     private List<TagToCat> tagToCats = new ArrayList<>();
 
     @Builder
-    public Cat(String name, LocalDateTime birthDate, String sex, int weight, String body) {
+    public Cat(String name, LocalDateTime birthDate, String sex, int weight, String body, String image) {
         this.name = name;
         this.birthDate = birthDate;
         this.sex = sex;
         this.weight = weight;
         this.body = body;
+        this.image = image;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
@@ -22,6 +22,7 @@ public interface CatMapper {
                 .sex(catPostDto.getSex())
                 .weight(catPostDto.getWeight())
                 .body(catPostDto.getBody())
+                .image(catPostDto.getImage())
                 .build();
         return cat;
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -56,15 +56,16 @@ public class CatService {
         catRepository.delete(findCat);
     }
 
-    public Cat updateCat(Cat cat, String breed, String email) {
-        Cat findCat = findVerifiedCat(cat.getCatId());
+    public Cat updateCat(long catId, Cat cat, String breed, String email) {
+        Cat findCat = findVerifiedCat(catId);
         // TODO:  CatInfo 구현 후 주석 제거 필요
 //        CatInfo findBreed = breedService.findByKorName(breed);
 //        cat.setBreed(findBreed);
         // 요청을 보낸 User 가 등록한 User 와 동일한지 확인
-        if (findCat.getUser().getEmail() != email) {
+        if (!findCat.getUser().getEmail().equals(email)) {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
         }
+
         Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
         return catRepository.save(updatingCat);
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -17,24 +17,20 @@ import java.util.Optional;
 public class CatService {
     private final CatRepository catRepository;
     private final UserService userService;
-    private final CatTagService catTagService;
     private final CustomBeanUtils<Cat> beanUtils;
 
-    public CatService(CatRepository catRepository, UserService userService, CatTagService catTagService,
-                      CustomBeanUtils beanUtils) {
+    public CatService(CatRepository catRepository, UserService userService, CustomBeanUtils beanUtils) {
         this.catRepository = catRepository;
         this.userService = userService;
-        this.catTagService = catTagService;
         this.beanUtils = beanUtils;
     }
 
-    public Cat createCat(Cat cat, String breed, List<CatTag> catTags, String email) {
+    public Cat createCat(Cat cat, String breed, String email) {
         // TODO: breed(CatInfo) 정보 꺼내서 Cat 에 저장 필요
         User findUser = userService.findVerifiedEmail(email);
         cat.setUser(findUser);
-        Cat createdCat = catRepository.save(cat);
-        catTagService.saveTag(catTags, createdCat);
-        return createdCat;
+
+        return catRepository.save(cat);
     }
 
 
@@ -60,7 +56,7 @@ public class CatService {
         catRepository.delete(findCat);
     }
 
-    public Cat updateCat(Cat cat, String breed, List<CatTag> catTags, String email) {
+    public Cat updateCat(Cat cat, String breed, String email) {
         Cat findCat = findVerifiedCat(cat.getCatId());
         // TODO:  CatInfo 구현 후 주석 제거 필요
 //        CatInfo findBreed = breedService.findByKorName(breed);
@@ -70,7 +66,6 @@ public class CatService {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
         }
         Cat updatingCat = beanUtils.copyNonNullProperties(cat, findCat);
-        catTagService.updateTag(catTags, updatingCat);
         return catRepository.save(updatingCat);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatTagService.java
@@ -27,8 +27,8 @@ public class CatTagService {
 
     public List<CatTag> saveTag(List<CatTag> catTags, Cat cat) {
         catTags.forEach(catTag -> {
-            catTag = findExistCatTag(catTag);
-            TagToCat tagToCat = new TagToCat(catTag, cat);
+            CatTag saveCatTag = findExistCatTag(catTag);
+            TagToCat tagToCat = new TagToCat(saveCatTag, cat);
             saveTagToCat(tagToCat);
         });
         return catTags;
@@ -40,13 +40,8 @@ public class CatTagService {
         return findCatTag;
     }
 
-    public TagToCat saveTagToCat(TagToCat tagToCat) {
-        TagToCat createdTagToCat = tagToCatRepository.save(tagToCat);
-        return createdTagToCat;
-    }
-
-    public void removeTagToCats(List<TagToCat> tagToCats) {
-        tagToCatRepository.deleteAll(tagToCats);
+    public void saveTagToCat(TagToCat tagToCat) {
+        tagToCatRepository.save(tagToCat);
     }
 
     public List<CatTag> updateTag (List<CatTag> catTags, Cat cat) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/controller/UserController.java
@@ -95,10 +95,10 @@ public class UserController {
                     @ApiResponse(responseCode = "409", description = "이미 사용 중인 이름")
             })
     @PatchMapping("/{user-id}")
-    public ResponseEntity patchUser(@PathVariable("user-id") Long userId,
+    public ResponseEntity patchUser(@PathVariable("user-id") @Positive long userId,
                                     @Valid @RequestBody UserPatchDto requestBody) {
         User user = userMapper.userPatchDtoToUser(requestBody);
-        User updateUser = userService.updateUser(user);
+        User updateUser = userService.updateUser(user, userId);
         return new ResponseEntity<>(userMapper.userToUserPatchResponseDto(updateUser), HttpStatus.OK);
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -42,9 +42,9 @@ public class UserService {
         return userRepository.findAll(pageRequest);
     }
 
-    public User updateUser(User user) {
+    public User updateUser(User user, long userId) {
         verifiedExistedName(user.getName());
-        User findUser = findVerifiedUser(user.getUserId());
+        User findUser = findVerifiedUser(userId);
         User updateUser = beanUtils.copyNonNullProperties(user, findUser);
         return userRepository.save(updateUser);
     }


### PR DESCRIPTION
## 주요 변경 사항
- CatMapper.catPostDtoToCat에 image 매핑 코드 추가
- Cat Builder 생성자에 매개변수 image 추가
- CatTagService를 CatService에 주입하던 것을 CatController에 주입하도록 수정
- patch-cat 에서 catId를 서비스에 같이 전달하여 findVerifiedCat 호출시 매개변수로 사용
- patch-user 에서 userId를 서비스에 같이 전달하여 findVerifiedUser 호출시 매개변수로 사용

## 코드 변경 이유
- post-cat 요청 시 image 정보 누락되어 null로 들어가는 오류 있어서 수정했습니다.
- 같은 도메인의 서비스는 컨트롤러에서 주입하는것이 적절하다 판단하여 CatTagService를 CatController에 주입하도록 수정했습니다.
- patch-cat, patch-user 에서 Id와 수정할정보를 따로 받아서 cat을 service에 전달하는데 수정할 정보에 id를 넣지 않은 채로 전달하여 id null 값이라 NullPointException 발생하여 수정했습니다. 

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatController, CatService
- UserController, UserService

## 연결된 이슈
close #173 

## 자료 (스크린샷 등)
