### PR TITLE
Feat: main페이지 layout제작

### DIFF
--- a/client/src/layout/MainLayout.tsx
+++ b/client/src/layout/MainLayout.tsx
@@ -1,0 +1,106 @@
+import { CameraIcon, HeartIcon } from '@Assets/icons'
+import { BOARD_PATH } from '@Routes/board.routes'
+import { FEED_PATH } from '@Routes/feed.routes'
+import { NavLink, Outlet } from 'react-router-dom'
+import styled from 'styled-components'
+
+const SNavLayout = styled.div`
+  position: relative;
+  display: flex;
+  justify-content: space-around;
+  align-items: center;
+  width: 173px;
+  height: 34px;
+  margin: 15px auto 12px auto;
+
+  background: rgba(198, 198, 198, 0.2);
+  border-radius: 36px;
+
+  .feeds,
+  .boards {
+    color: white;
+    transition: 1s ease-in-out;
+  }
+
+  .feeds ~ .decoreation {
+    left: 0%;
+  }
+
+  .boards ~ .decoreation {
+    left: 50%;
+  }
+`
+
+const SDecoreation = styled.div`
+  position: absolute;
+  z-index: -1;
+  height: 100%;
+  width: 50%;
+  text-align: center;
+  background: #f8adb2;
+  border-radius: 28px;
+  left: 50%;
+
+  transition: left 1s;
+`
+
+const Nav = () => {
+  return (
+    <SNavLayout>
+      <NavLink
+        className={({ isActive }) => (isActive ? 'feeds' : '')}
+        to={FEED_PATH}
+      >
+        냥이생활
+      </NavLink>
+      <NavLink
+        className={({ isActive }) => (isActive ? 'boards' : '')}
+        to={BOARD_PATH}
+      >
+        집사생활
+      </NavLink>
+      <SDecoreation className="decoreation" />
+    </SNavLayout>
+  )
+}
+
+const STapBarLayout = styled.div`
+  display: flex;
+  flex-direction: row;
+  justify-content: space-around;
+  align-items: center;
+  padding: 0px 25px;
+
+  position: absolute;
+  width: 300px;
+  height: 50px;
+  left: calc(50% - 300px / 2 - 0.5px);
+  bottom: 41px;
+
+  background: #ffffff;
+  box-shadow: 0px 1px 4px rgba(0, 0, 0, 0.25);
+  border-radius: 43px;
+`
+
+const TapBar = () => {
+  return (
+    <STapBarLayout>
+      <NavLink to={FEED_PATH}>
+        <CameraIcon />
+      </NavLink>
+      <NavLink to="login">
+        <HeartIcon />
+      </NavLink>
+    </STapBarLayout>
+  )
+}
+
+export const MainLayout = () => {
+  return (
+    <>
+      <Nav />
+      <Outlet />
+      <TapBar />
+    </>
+  )
+}

--- a/client/src/layout/PhoneLayout.tsx
+++ b/client/src/layout/PhoneLayout.tsx
@@ -1,4 +1,4 @@
-import React, { FC } from 'react'
+import { FC } from 'react'
 import { Outlet } from 'react-router-dom'
 import styled, { css, CSSProp } from 'styled-components'
 
@@ -19,6 +19,7 @@ const phoneSize = {
 
 const PhoneBox = styled.div<{ cssProp?: CSSProp }>(
   ({ cssProp }) => css`
+    position: relative;
     border: 3px solid black;
     width: 100%;
     height: 100%;

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -5,11 +5,13 @@ import { RouteObject, useRoutes } from 'react-router-dom'
 import { boardRoutes } from './board.routes'
 import { errorRoutes } from './error.routes'
 import { feedRoutes } from './feed.routes'
+import { mainRoutes } from './main.routes'
 
 const appRoutes: RouteObject = {
   path: '/',
   element: <DashBoard />,
   children: [
+    mainRoutes,
     { path: 'login', element: <Login /> },
     { path: 'signup', element: <Signup /> },
     feedRoutes,

--- a/client/src/routes/board.routes.tsx
+++ b/client/src/routes/board.routes.tsx
@@ -1,7 +1,7 @@
 import { lazy } from 'react'
 import { RouteObject } from 'react-router-dom'
 
-const Boards = lazy(() => import('@pages/Board/Boards'))
+// const Boards = lazy(() => import('@pages/Board/Boards'))
 const BoardDetail = lazy(() => import('@pages/Board/BoardDetail'))
 const NewBoard = lazy(() => import('@pages/Board/NewBoard'))
 const EditBoard = lazy(() => import('@pages/Board/EditBoard'))
@@ -11,7 +11,7 @@ export const BOARD_PATH = '%EC%A7%91%EC%82%AC%EC%83%9D%ED%99%9C'
 export const boardRoutes: RouteObject = {
   path: BOARD_PATH,
   children: [
-    { index: true, element: <Boards /> },
+    // { index: true, element: <Boards /> },
     { path: ':id', element: <BoardDetail /> },
     { path: 'new', element: <NewBoard /> },
     {

--- a/client/src/routes/feed.routes.tsx
+++ b/client/src/routes/feed.routes.tsx
@@ -1,7 +1,7 @@
 import { lazy } from 'react'
 import { RouteObject } from 'react-router-dom'
 
-const Feed = lazy(() => import('@pages/Feed/Feeds'))
+// const Feed = lazy(() => import('@pages/Feed/Feeds'))
 const FeedDetail = lazy(() => import('@pages/Feed/FeedDetail'))
 const NewFeed = lazy(() => import('@pages/Feed/NewFeed'))
 const EditFeed = lazy(() => import('@pages/Feed/EditFeed'))
@@ -11,7 +11,7 @@ export const FEED_PATH = '%EB%83%A5%EC%9D%B4%EC%83%9D%ED%99%9C'
 export const feedRoutes: RouteObject = {
   path: FEED_PATH,
   children: [
-    { index: true, element: <Feed /> },
+    // { index: true, element: <Feed /> },
     { path: ':id', element: <FeedDetail /> },
     { path: 'new', element: <NewFeed /> },
     {

--- a/client/src/routes/index.ts
+++ b/client/src/routes/index.ts
@@ -3,5 +3,6 @@ import AppRoutes from './AppRoutes'
 export * from './error.routes'
 export * from './feed.routes'
 export * from './board.routes'
+export * from './main.routes'
 
 export default AppRoutes

--- a/client/src/routes/main.routes.tsx
+++ b/client/src/routes/main.routes.tsx
@@ -1,0 +1,16 @@
+import { MainLayout } from '@Layout/MainLayout'
+import Boards from '@pages/Board/Boards'
+import Feeds from '@pages/Feed/Feeds'
+import { Navigate, RouteObject } from 'react-router-dom'
+import { BOARD_PATH } from './board.routes'
+import { FEED_PATH } from './feed.routes'
+
+export const mainRoutes: RouteObject = {
+  path: '',
+  element: <MainLayout />,
+  children: [
+    { index: true, element: <Navigate to={FEED_PATH} /> },
+    { path: FEED_PATH, element: <Feeds /> },
+    { path: BOARD_PATH, element: <Boards /> },
+  ],
+}


### PR DESCRIPTION
## 주요 변경 사항
main 페이지인 /집사생활, /냥이생활에 대응하는 layout을 제작하였습니다.
집사생활 페이지와 냥이생활 페이지는 다음과 같이
- 상단의 화면 전환 nav 바
- 하단의 tap 바
를 동일하게 공유합니다.
때문에 새로운 레이아웃을 작성하여 라우팅하여 화면 전환시 nav, tap바는 유지하면서 세부 화면만 로딩하는 것이 좋다고 판단하였습니다.
<img width="248" alt="스크린샷 2022-10-02 오후 10 35 10" src="https://user-images.githubusercontent.com/96106122/193456863-b1350ef0-8eb8-4555-8602-8c0350bac330.png">

layout을 다음과 같이 작성하고 feeds와 boards에 사용할 라우터 객체를 만들어 주었습니다.
```jsx
// src/layout/MainLayout.tsx

export const MainLayout = () => {
  return (
    <>
      /<Nav />
      /<Outlet />
      /<TapBar />
    </>
  )
}
```
```jsx
// src/routes/main.routes.tsx
export const mainRoutes: RouteObject = {
  path: '',
  element: <MainLayout />,
  children: [
    { index: true, element: <Navigate to={FEED_PATH} /> },
    { path: FEED_PATH, element: <Feeds /> },
    { path: BOARD_PATH, element: <Boards /> },
  ],
}
```
최종적으로 appRouter에 추가해 주었습니다.
```jsx
// src/routes/AppRoutes.tsx
const appRoutes: RouteObject = {
  path: '/',
  element: <DashBoard />,
  children: [
    mainRoutes,
    // 다른 routes들
  ]
}
```
## 코드 변경 이유
이부분을 지우고 내용을 적어주세요

## 코드 리뷰 시 중점적으로 봐야할 부분
이부분을 지우고 내용을 적어주세요.

## 연결된 이슈

## 자료 (스크린샷 등)
