### PR TITLE
feat: logout 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -12,7 +12,8 @@ public enum ExceptionCode {
     BOARD_NOT_FOUND(404, "Board not found"),
     BOARD_TAG_NOT_FOUND(404, "Board tag not found"),
     INVALID_USER(405, "Method not allowed"),
-    FEED_NOT_FOUND(404, "Feed not found");
+    FEED_NOT_FOUND(404, "Feed not found"),
+    REFRESH_TOKEN_NOT_FOUND(404, "Refresh token not found");
 
     @Getter
     private final int status;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
@@ -14,10 +14,13 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.User;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RestController;
 
+import javax.servlet.http.HttpServletRequest;
 import javax.transaction.Transactional;
 
 //@Tag(name = "Auth", description = "인증 API")
@@ -57,5 +60,20 @@ public class AuthController {
     @PostMapping("/reissue")
     public ResponseEntity reissue(@RequestBody TokenRequestDto tokenRequestDto) {
         return new ResponseEntity<>(authService.reissue(tokenRequestDto), HttpStatus.OK);
+    }
+
+    @Operation(summary = "로그아웃",
+        responses = {
+            @ApiResponse(responseCode = "200", description = "로그아웃 성공"),
+            @ApiResponse(responseCode = "404", description = "존재하지 않는 Refresh token")
+        }
+    )
+    @PostMapping("/logout")
+    public ResponseEntity logout(@RequestBody TokenRequestDto tokenRequestDto,
+                                 @AuthenticationPrincipal User user) {
+        if(user != null) {
+            authService.logout(tokenRequestDto);
+        }
+        return new ResponseEntity<>(HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/refreshToken/RefreshTokenRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/refreshToken/RefreshTokenRepository.java
@@ -6,4 +6,5 @@ import java.util.Optional;
 
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
     Optional<RefreshToken> findByKey(String key);
+    Optional<RefreshToken> findByValue(String value);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/service/AuthService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/service/AuthService.java
@@ -1,5 +1,7 @@
 package com.twentyfour_seven.catvillage.security.service;
 
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.security.provider.JwtTokenizer;
 import com.twentyfour_seven.catvillage.security.dto.TokenDto;
 import com.twentyfour_seven.catvillage.security.dto.TokenRequestDto;
@@ -17,6 +19,8 @@ import org.springframework.security.config.annotation.authentication.builders.Au
 import org.springframework.security.core.Authentication;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
+
+import java.util.Optional;
 
 @Service
 @RequiredArgsConstructor
@@ -91,6 +95,16 @@ public class AuthService {
 
         // 토큰 발급
         return tokenDto;
+    }
+
+    public void logout(TokenRequestDto tokenRequestDto) {
+        // TODO: access token은 black list table에 등록하여 더 이상 해당 토큰으로 로그인 못 하도록 처리 필요
+
+        // Refresh token 제거
+        RefreshToken findRefreshToken = refreshTokenRepository.findByKey(tokenRequestDto.getRefreshToken())
+                .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REFRESH_TOKEN_NOT_FOUND));
+
+        refreshTokenRepository.delete(findRefreshToken);
     }
 
     // 클래스 내부에서만 사용 가능한 토큰 생성하는 로직

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/service/AuthService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/service/AuthService.java
@@ -101,7 +101,7 @@ public class AuthService {
         // TODO: access token은 black list table에 등록하여 더 이상 해당 토큰으로 로그인 못 하도록 처리 필요
 
         // Refresh token 제거
-        RefreshToken findRefreshToken = refreshTokenRepository.findByKey(tokenRequestDto.getRefreshToken())
+        RefreshToken findRefreshToken = refreshTokenRepository.findByValue(tokenRequestDto.getRefreshToken())
                 .orElseThrow(() -> new BusinessLogicException(ExceptionCode.REFRESH_TOKEN_NOT_FOUND));
 
         refreshTokenRepository.delete(findRefreshToken);


### PR DESCRIPTION
## 주요 변경 사항
- accessToken 및 refreshToken을 받은 후 해당 토큰들을 폐기하는 동작을 수행하는 logout API 추가
- 입력 받은 accessToken으로 더 이상 로그인 하지 못 하게 하는 기능은 추후 개발로 미뤄져 있는 상태
- 현재 Refresh Token만 삭제하는 로직 수행

## 코드 변경 이유
- logout을 위한 로직 추가
- 입력 받은 refresh token이 존재하지 않는 경우 에러 반환
- 존재하는 refresh token인 경우, 해당 refresh token을 삭제

## 코드 리뷰 시 중점적으로 봐야할 부분
이부분을 지우고 내용을 적어주세요.

## 연결된 이슈
resolved #19

## 자료 (스크린샷 등)
