### PR TITLE
fix: security 제공 logout 비활성화

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
@@ -60,7 +60,11 @@ public class SecurityConfig {
                 .and()
                 .oauth2Login()
                 .userInfoEndpoint()
-                .userService(customOAuth2UserService);
+                .userService(customOAuth2UserService)
+                .and()
+                .and()
+                .logout()
+                .disable();
         return http.build();
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- 직접 구현한 logout을 사용하므로 security에서 제공하는 logout 비활성화
- 해당 문제로 logout이 안되던 문제 발생

## 코드 변경 이유
- security에서 기본적으로 제공되는 logout 기능과 충돌이 발생하였기에 이를 해결하기 위함

## 코드 리뷰 시 중점적으로 봐야할 부분
- security config에서 logout disable 처리

## 연결된 이슈

## 자료 (스크린샷 등)
