### PR TITLE
feat: business logic exception handler 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/ExceptionCode.java
@@ -15,7 +15,8 @@ public enum ExceptionCode {
     FEED_NOT_FOUND(404, "Feed not found"),
     BOARD_COMMENT_NOT_FOUND(404, "Board comment not found"),
     COMMENT_NOT_FOUND(404, "Comment not found"),
-    REFRESH_TOKEN_NOT_FOUND(404, "Refresh token not found");
+    REFRESH_TOKEN_NOT_FOUND(404, "Refresh token not found"),
+    INTERNAL_SERVER_ERROR(500, "Internal server error");
 
     @Getter
     private final int status;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/config/BusinessLogicExceptionHandler.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/config/BusinessLogicExceptionHandler.java
@@ -1,0 +1,28 @@
+package com.twentyfour_seven.catvillage.exception.config;
+
+import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
+import com.twentyfour_seven.catvillage.exception.dto.ErrorResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+public class BusinessLogicExceptionHandler {
+    @ExceptionHandler(BusinessLogicException.class)
+    public ResponseEntity<?> handleCustomRuntimeException(BusinessLogicException ex) {
+        ErrorResponse response = new ErrorResponse(ex.getExceptionCode());
+        return new ResponseEntity<>(response, HttpStatus.valueOf(ex.getExceptionCode().getStatus()));
+    }
+
+//    @ExceptionHandler(Exception.class)
+//    public ResponseEntity<?> handleException(Exception ex) {
+//        ErrorResponse response = new ErrorResponse(500, ex.getMessage());
+//        if(ex.getMessage() == null) {
+//            response.setMessage("Internal server error");
+//        } else if (ex.getMessage().equals("자격 증명에 실패하였습니다.")) {
+//                response.setStatus(401);
+//        }
+//        return new ResponseEntity<>(response, HttpStatus.valueOf(response.getStatus()));
+//    }
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/dto/ErrorResponse.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/exception/dto/ErrorResponse.java
@@ -1,0 +1,22 @@
+package com.twentyfour_seven.catvillage.exception.dto;
+
+import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class ErrorResponse {
+    private int status;
+    private String message;
+
+    public ErrorResponse(ExceptionCode exceptionCode) {
+        this.status = exceptionCode.getStatus();
+        this.message = exceptionCode.getMessage();
+    }
+
+    public ErrorResponse(int status, String message) {
+        this.status = status;
+        this.message = message;
+    }
+}


### PR DESCRIPTION
## 주요 변경 사항
- business logic exception 발생 시, 해당 Error status code 및 message를 반환하도록 하는 handler 추가
- 현재 business logic exception에 대해서만 핸들링을 하고 있으며, 인증 관련 예외는 추후에 추가 필요

## 코드 변경 이유
- 예외 발생 시, 어떤 이유로 발생 했는지를 프론트엔드에 전달하기 위한 예외 핸들러 추가
- `@RestControllerAdvice` 어노테이션을 사용하여 RestController에서 발생하는 예외를 핸들링
- `@ExceptionHandler` 어노테이션을 사용하여 어떠한 예외를 처리할지 지정하여 핸들링
- 인증 관련 예외는 controller 단에서 발생하는게 아닌 filter 단에서 발생하므로 해당 방법으로 핸들링 불가
- 인증 관련 예외는 `AuthenticationEntryPoint` interface를 상속 받아서 처리할 수 있는 것으로 파악
  - 시도는 해보았으나 잘 안되어 이후에 추가 구현 필요 (현 수정에 코드 반영 X)

## 코드 리뷰 시 중점적으로 봐야할 부분
- BusinessLogicExceptionHandler class : 실질적으로 예외를 핸들링하는 클래스
- ErrorResponse class : 예외 발생 시 해당 내용을 전달하는 DTO 역할의 클래스

## 연결된 이슈
resolved #72

## 자료 (스크린샷 등)
