### PR TITLE
feat: Swagger에 Post-Cat 요청 dto에 대한 설명 작성

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
@@ -28,7 +28,7 @@ public class CatPostDto {
     @ApiModelProperty(value = "고양이 탄생일", example = "27")
     private int birthDay;
 
-    @ApiModelProperty(value = "고양이 품종명(등록되어 있는 품종만 선택만 저장가능)", example = "셀커크렉스")
+    @ApiModelProperty(value = "고양이 품종명(등록되어 있는 품종만 선택 및 저장가능)", example = "셀커크렉스")
     private String breed;
 
     @ApiModelProperty(value = "고양이 성별", example = "m")

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatPostDto.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
@@ -13,24 +14,35 @@ import java.util.List;
 @Setter
 @Validated
 public class CatPostDto {
+    @ApiModelProperty(value = "고양이 이름(글자제한 16자)", example = "수라", required = true)
     @Length(max = 16)
     @NotBlank
     private String name;
 
+    @ApiModelProperty(value = "고양이 탄생년도", example = "2019")
     private int birthYear;
+
+    @ApiModelProperty(value = "고양이 탄생월", example = "9")
     private int birthMonth;
+
+    @ApiModelProperty(value = "고양이 탄생일", example = "27")
     private int birthDay;
 
+    @ApiModelProperty(value = "고양이 품종명(등록되어 있는 품종만 선택만 저장가능)", example = "셀커크렉스")
     private String breed;
 
+    @ApiModelProperty(value = "고양이 성별", example = "m")
     @Pattern(regexp = "^[mf]$")
     private String sex;
 
+    @ApiModelProperty(value = "고양이 몸무게(g단위로 전송)", example = "5500")
     private int weight;
 
-    @Length(max = 50)
+    @ApiModelProperty(value = "고양이 프로필 이미지 경로", example = "https://image.catvillage.shop.s3.ap-northeast-2.amazonaws.com/catvillage/images/9f39a517-3555-47b1-a0d4-344e73af1d0b-feed-image-1.jpg")
+    @Length(max = 500)
     private String image;
 
+    @ApiModelProperty(value = "고양이 소개글(글자제한 1000자)", example = "안녕하세요! 수라입니다!")
     @Length(max = 1000)
     private String body;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatTagPostDto.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Getter;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
@@ -9,6 +10,7 @@ import org.springframework.validation.annotation.Validated;
 @Setter
 @Validated
 public class CatTagPostDto {
+    @ApiModelProperty(value = "태그 내용(길이제한 15자)", example = "냥아치")
     @Length(max = 15)
     private String tag;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -7,6 +7,7 @@ import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentPostResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.comment.BoardUserCommentResponseDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
+import com.twentyfour_seven.catvillage.cat.dto.CatTagPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatTagResponseDto;
 import com.twentyfour_seven.catvillage.dto.MultiBoardResponseDto;
 import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
@@ -74,7 +75,9 @@ public class SwaggerConfig {
                         typeResolver.resolve(UserMyInfoDto.class),
                         typeResolver.resolve(BoardCommentPostResponseDto.class),
                         typeResolver.resolve(FeedCommentPostDto.class),
-                        typeResolver.resolve(FeedCommentGetDto.class)
+                        typeResolver.resolve(FeedCommentGetDto.class),
+                        typeResolver.resolve(CatTagPostDto.class),
+                        typeResolver.resolve(CatTagResponseDto.class)
                 )
 //                .useDefaultResponseMessages(true)
                 .useDefaultResponseMessages(false)


### PR DESCRIPTION
## 주요 변경 사항
- CatPostDto에 image 길이제한 max 500으로 수정
- CatPostDto와 CatTagPostDto에 변수 별로 설명, 예시 작성

## 코드 변경 이유
- 고양이 등록시 image 경로 길이제한이 50으로 되어 있어서 DB설계에 맞추어 500으로 늘렸습니다.
- 고양이 등록은 프론트엔드 개발시 헷갈릴 수 있어서 변수에 설명과 제한, 예시를 작성하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- CatPostDto
- CatTagPostDto

## 연결된 이슈
- close #224 

## 자료 (스크린샷 등)
