### PR TITLE
fix: 집사생활 등록 및 수정 시 에러 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -74,7 +74,7 @@ public class BoardController {
     public ResponseEntity getBoard(@Positive @PathVariable("boards-id") Long boardId) {
         Board board = boardService.findBoard(boardId);
         BoardGetResponseDto responseDto = boardMapper.boardToBoardGetResponseDto(board);
-        responseDto.setComments(boardCommentMapper.boardCommentsToBoardUserCommentResponseDtos(board.getBoardComments()));
+        responseDto.setComments(boardCommentMapper.boardCommentsToBoardCommentResponseDtos(board.getBoardComments()));
         return new ResponseEntity<>(responseDto, HttpStatus.OK);
     }
 
@@ -112,6 +112,7 @@ public class BoardController {
     public ResponseEntity patchBoard(@AuthenticationPrincipal org.springframework.security.core.userdetails.User user,
                                      @Positive @PathVariable("boards-id") Long boardId,
                                      @Valid @RequestBody BoardPatchDto requestBody) {
+        requestBody.setBoardId(boardId);
         Board board = boardMapper.boardPatchDtoToBoard(requestBody);
         User findUser = userService.findVerifiedEmail(user.getUsername());
         board.setUser(findUser);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardGetResponseDto.java
@@ -1,7 +1,7 @@
 package com.twentyfour_seven.catvillage.board.dto;
 
 import com.fasterxml.jackson.annotation.JsonFormat;
-import com.twentyfour_seven.catvillage.board.dto.comment.BoardUserCommentResponseDto;
+import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentResponseDto;
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import lombok.Builder;
 import lombok.Getter;
@@ -27,10 +27,10 @@ public class BoardGetResponseDto {
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdDate;
     private Boolean isLike;
-    private List<BoardUserCommentResponseDto> comments;
+    private List<BoardCommentResponseDto> comments;
 
     @Builder
-    public BoardGetResponseDto(Long boardId, String title, String body, String name, List<BoardTagDto> tags, List<PictureDto> pictures, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate, Boolean isLike, List<BoardUserCommentResponseDto> comments) {
+    public BoardGetResponseDto(Long boardId, String title, String body, String name, List<BoardTagDto> tags, List<PictureDto> pictures, Long viewCount, Long likeCount, Long commentCount, LocalDateTime createdDate, Boolean isLike, List<BoardCommentResponseDto> comments) {
         this.boardId = boardId;
         this.title = title;
         this.body = body;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -18,8 +19,8 @@ public class BoardPatchDto {
     private String title;
     @Length(max = 1000)
     private String body;
-    private List<BoardTagDto> tags;
-    private List<PictureDto> pictures;
+    private List<BoardTagDto> tags = new ArrayList<>();
+    private List<PictureDto> pictures = new ArrayList<>();
 
     @Builder
     public BoardPatchDto(Long boardId, String title, String body, List<BoardTagDto> tags, List<PictureDto> pictures) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Getter
@@ -17,8 +18,8 @@ public class BoardPostDto {
     private String title;
     @Length(max = 1000)
     private String body;
-    private List<BoardTagDto> tags;
-    private List<PictureDto> pictures;
+    private List<BoardTagDto> tags = new ArrayList<>();
+    private List<PictureDto> pictures = new ArrayList<>();
 
     @Builder
     public BoardPostDto(String title, String body, List<BoardTagDto> tags, List<PictureDto> pictures) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/comment/BoardCommentResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/comment/BoardCommentResponseDto.java
@@ -15,15 +15,17 @@ public class BoardCommentResponseDto {
     private Long boardCommentId;
     private String body;
     private String name;
+    private String link;
     private Long likeCount;
     @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
     private LocalDateTime createdDate;
 
     @Builder
-    public BoardCommentResponseDto(Long boardCommentId, String body, String name, Long likeCount, LocalDateTime createdDate) {
+    public BoardCommentResponseDto(Long boardCommentId, String body, String name, String link, Long likeCount, LocalDateTime createdDate) {
         this.boardCommentId = boardCommentId;
         this.body = body;
         this.name = name;
+        this.link = link;
         this.likeCount = likeCount;
         this.createdDate = createdDate;
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
@@ -1,9 +1,6 @@
 package com.twentyfour_seven.catvillage.board.mapper;
 
-import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentPatchDto;
-import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentPostDto;
-import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentPostResponseDto;
-import com.twentyfour_seven.catvillage.board.dto.comment.BoardUserCommentResponseDto;
+import com.twentyfour_seven.catvillage.board.dto.comment.*;
 import com.twentyfour_seven.catvillage.board.entity.Board;
 import com.twentyfour_seven.catvillage.board.entity.BoardComment;
 import org.mapstruct.Mapper;
@@ -28,6 +25,23 @@ public interface BoardCommentMapper {
     }
 
     List<BoardUserCommentResponseDto> boardCommentsToBoardUserCommentResponseDtos(List<BoardComment> boardComments);
+
+    default BoardCommentResponseDto boardCommentToBoardCommentResponseDto(BoardComment boardComment) {
+        if(boardComment == null) {
+            return null;
+        } else {
+            return BoardCommentResponseDto.builder()
+                    .boardCommentId(boardComment.getBoardCommentId())
+                    .body(boardComment.getBody())
+                    .name(boardComment.getUser().getName())
+                    .link("https://catvillage.tk/users/" + boardComment.getUser().getUserId())
+                    .likeCount(boardComment.getLikeCount())
+                    .createdDate(boardComment.getCreatedDate())
+                    .build();
+        }
+    }
+
+    List<BoardCommentResponseDto> boardCommentsToBoardCommentResponseDtos(List<BoardComment> boardComments);
 
     default BoardComment boardCommentPostDtoToBoardComment(BoardCommentPostDto requestBody) {
         if(requestBody == null) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -7,10 +7,9 @@ import com.twentyfour_seven.catvillage.board.repository.BoardRepository;
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
-import com.twentyfour_seven.catvillage.user.entity.User;
-import com.twentyfour_seven.catvillage.utils.CustomBeanUtils;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
+import com.twentyfour_seven.catvillage.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
@@ -64,13 +63,23 @@ public class BoardService {
 
     public Board updateBoard(Board board, List<BoardTagDto> tags, List<PictureDto> pictures) {
         Board findBoard = findVerifiedBoard(board.getBoardId());
-        if(!findBoard.getUser().equals(board.getUser())) {
+        if (!findBoard.getUser().equals(board.getUser())) {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
+        }
+
+        // 제목 변경 : 제목은 공백일 수 없다
+        if (!board.getTitle().isEmpty()) {
+            findBoard.setTitle(board.getTitle());
+        }
+
+        // 본문 변경 : 본문은 공백일 수 있다.
+        if (board.getBody() != null) {
+            findBoard.setBody(board.getBody());
         }
 
         // 제거된 태그 삭제
         findBoard.getTagToBoards().forEach(e -> {
-            if(!tags.contains(new BoardTagDto(e.getBoardTag()))) {
+            if (!tags.contains(new BoardTagDto(e.getBoardTag()))) {
                 tagToBoardService.deleteTagToBoard(e);
             }
         });
@@ -84,7 +93,7 @@ public class BoardService {
         // 삭제된 사진 경로는 DB 및 리스트에서 제거
         findBoard.getPictures().forEach(e -> {
             PictureDto dto = new PictureDto(e);
-            if(pictures.contains(dto)) {
+            if (pictures.contains(dto)) {
                 pictures.remove(dto);
             } else {
                 pictureService.removePicture(e.getPictureId());
@@ -106,7 +115,7 @@ public class BoardService {
 
     public void deleteBoard(User user, Long boardId) {
         Board findBoard = findVerifiedBoard(boardId);
-        if(!findBoard.getUser().equals(user)) {
+        if (!findBoard.getUser().equals(user)) {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
         }
         boardRepository.delete(findBoard);


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활 게시글 등록 및 수정 시 발생할 수 있는 NullPointerException 예방
- 집사생활 게시글 수정 시 title과 body의 수정 로직이 누락된 부분 추가
- 집사생활 특정 게시글 조회 시, 댓글 출력에 필요한 데이터로 변경 (이전 코드는 My page에서 나와야 하는 데이터)
- 위 댓글 출력에 필요한 데이터에 댓글 작성자의 유저 페이지 링크 추가

## 코드 변경 이유
- 등록 및 수정 시 body에 tags 및 pictures가 넘어오지 않으면 NullPointException이 발생하기 때문에 이를 예방하고자 tags, pictures에 `new ArrayList<>();`를 할당, 데이터 정상적으로 들어오는 것 확인 완료
- 수정 시 title과 body를 수정하는 로직이 빠져있어서 수정
- 특정 게시글 조회 시 나오는 댓글 데이터가 부적절하여 변경

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardService class : 게시글 수정 로직에서 title, body 추가된 코드
- BoardController class : 댓글 응답으로 `BoardUserCommentResponseDto`에서 `BoardCommentResponseDto`로 변경된 점

## 연결된 이슈

## 자료 (스크린샷 등)
