### PR TITLE
fix: tagName 칼럼에 Unique 속성 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/entity/BoardTag.java
@@ -18,7 +18,7 @@ public class BoardTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long boardTagId;
 
-    @Column(name = "TAG_NAME", length = 15, nullable = false)
+    @Column(name = "TAG_NAME", length = 15, nullable = false, unique = true)
     private String tagName;
 
     @OneToMany(mappedBy = "boardTag", cascade = CascadeType.REMOVE)

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/CatTag.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/entity/CatTag.java
@@ -17,7 +17,7 @@ public class CatTag {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long tagId;
 
-    @Column(name = "TAG_NAME", length = 15, nullable = false)
+    @Column(name = "TAG_NAME", length = 15, nullable = false, unique = true)
     private String tagName;
 
     @OneToMany(mappedBy = "catTag")

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/CatInfo.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/CatInfo.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.annotation.JsonManagedReference;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
 import java.util.ArrayList;
@@ -11,13 +12,14 @@ import java.util.List;
 
 @Entity(name = "CAT_INFO")
 @Getter
+@NoArgsConstructor
 public class CatInfo {
     @Id
     @Column(name = "CAT_INFO_ID")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long catInfoId;
 
-    @Column(name = "KOR_NAME", nullable = false, length = 20)
+    @Column(name = "KOR_NAME", nullable = false, length = 20, unique = true)
     private String korName;
 
     @Column(name = "ENG_NAME", length = 20)

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/Disease.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/Disease.java
@@ -12,6 +12,6 @@ public class Disease {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long diseaseId;
 
-    @Column(name = "NAME", nullable = false, length = 30)
+    @Column(name = "NAME", nullable = false, length = 30, unique = true)
     private String name;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/FeedTag.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/entity/FeedTag.java
@@ -19,7 +19,7 @@ public class FeedTag {
     private Long feedTagId;
 
     @Setter
-    @Column(name = "TAG_NAME", length = 15, nullable = false)
+    @Column(name = "TAG_NAME", length = 15, nullable = false, unique = true)
     private String tagName;
 
     @OneToMany(mappedBy = "feedTag", cascade = CascadeType.REMOVE)


### PR DESCRIPTION
## 주요 변경 사항
- BoardTag, CatTag, FeedTag 의 tagName 칼럼을 Unique 값으로 설정하여 unique true 로 코드 변경
- Disease의 name 에 unique 속성 추가
- CatInfo의 korName에 unique 속성 추가

## 코드 변경 이유
- 테그 이름은 고유하기 때문에 DB에서 Unique 속성 부여하여 코드에서도 동일하게 적용했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- unique true 부분

## 연결된 이슈

## 자료 (스크린샷 등)
