### PR TITLE
[FE] 냥이생활 전체 피드 페이지 데이터 불러오는 로직 구현

### DIFF
--- a/client/src/@types/feed.ts
+++ b/client/src/@types/feed.ts
@@ -1,0 +1,19 @@
+export interface Feeds {
+  feed: Feed[]
+  follow: Follow[]
+  page: number
+  pageSize: number
+  totalElements: number
+  totalPages: number
+}
+
+export interface Feed {
+  feedId: number
+  image: string
+  like: boolean
+}
+
+export interface Follow {
+  catId: number
+  profileImage: string
+}

--- a/client/src/@types/feed.ts
+++ b/client/src/@types/feed.ts
@@ -5,6 +5,8 @@ export interface Feeds {
   pageSize: number
   totalElements: number
   totalPages: number
+  hasMoreFeed?: boolean
+  isLoading?: boolean
 }
 
 export interface Feed {

--- a/client/src/pages/Feed/Feeds/Feeds.style.ts
+++ b/client/src/pages/Feed/Feeds/Feeds.style.ts
@@ -1,0 +1,42 @@
+import styled, { css } from 'styled-components'
+
+export const FeedsLayout = styled.div`
+  margin: 0px 20px;
+  display: flex;
+  flex-direction: column;
+`
+
+export const FollowCatBox = styled.div`
+  display: flex;
+  justify-content: space-between;
+  padding: 10px 0;
+`
+
+export const FeedBox = styled.ul`
+  column-count: 2;
+`
+
+export const FeedItem = styled.li`
+  position: relative;
+  margin-bottom: 15px;
+  cursor: pointer;
+  > * {
+    border-radius: 10px;
+  }
+`
+export const SvgButtonCssProp = css`
+  position: absolute;
+  right: 8px;
+  top: 8px;
+  > * {
+    stroke-opacity: 0.3;
+    :hover {
+      stroke-width: 0;
+      fill: red;
+    }
+  }
+`
+
+export const AvatarCssProp = css`
+  cursor: pointer;
+`

--- a/client/src/pages/Feed/Feeds/Feeds.tsx
+++ b/client/src/pages/Feed/Feeds/Feeds.tsx
@@ -1,4 +1,47 @@
+import { Feeds } from '@Types/feed'
+import Image from '@Atoms/Image'
+import SvgButton from '@Atoms/SvgButton'
+import Avatar from '@Atoms/Avatar'
+import * as S from './Feeds.style'
+import { feedsDummyData } from './data'
+import { SvgButtonCssProp, AvatarCssProp } from './Feeds.style'
+
 const Feeds = () => {
-  return <div>Feeds</div>
+  const handleFeedClick = () => {
+    /* 특정 피드를 클릭했을 때 해당 피드 페이지로 이동하는 함수 */
+  }
+
+  const handleLikeClick = () => {
+    /* 좋아요 버튼을 클릭했을 때 실행되는 함수 */
+  }
+
+  const handleFollowClick = () => {
+    /* 팔로우한 고양이 프로필을 클릭했을 때 실행되는 함수 */
+  }
+
+  return (
+    <S.FeedsLayout>
+      <S.FollowCatBox>
+        {feedsDummyData.follow.map(item => (
+          <Avatar
+            key={item.catId}
+            diameter="70px"
+            imageUrl={item.profileImage}
+            cssProp={AvatarCssProp}
+          />
+        ))}
+      </S.FollowCatBox>
+      <S.FeedBox>
+        {feedsDummyData.feed.map(item => {
+          return (
+            <S.FeedItem key={item.feedId}>
+              <Image src={item.image} />
+              <SvgButton icon="HeartIcon" cssProp={SvgButtonCssProp} />
+            </S.FeedItem>
+          )
+        })}
+      </S.FeedBox>
+    </S.FeedsLayout>
+  )
 }
 export default Feeds

--- a/client/src/pages/Feed/Feeds/Feeds.tsx
+++ b/client/src/pages/Feed/Feeds/Feeds.tsx
@@ -2,11 +2,20 @@ import { Feeds } from '@Types/feed'
 import Image from '@Atoms/Image'
 import SvgButton from '@Atoms/SvgButton'
 import Avatar from '@Atoms/Avatar'
+import { useEffect } from 'react'
 import * as S from './Feeds.style'
-import { feedsDummyData } from './data'
 import { SvgButtonCssProp, AvatarCssProp } from './Feeds.style'
+import { useAppDispatch, useAppSelector } from '@/redux/store'
+import { getFeedsAsync } from '@/redux/actions/FeedsAction'
 
 const Feeds = () => {
+  const dispatch = useAppDispatch()
+  const { feed, follow } = useAppSelector(state => state.feeds)
+
+  useEffect(() => {
+    dispatch(getFeedsAsync())
+  }, [dispatch])
+
   const handleFeedClick = () => {
     /* 특정 피드를 클릭했을 때 해당 피드 페이지로 이동하는 함수 */
   }
@@ -22,24 +31,26 @@ const Feeds = () => {
   return (
     <S.FeedsLayout>
       <S.FollowCatBox>
-        {feedsDummyData.follow.map(item => (
-          <Avatar
-            key={item.catId}
-            diameter="70px"
-            imageUrl={item.profileImage}
-            cssProp={AvatarCssProp}
-          />
-        ))}
+        {follow &&
+          follow.map(item => (
+            <Avatar
+              key={item.catId}
+              diameter="70px"
+              imageUrl={item.profileImage}
+              cssProp={AvatarCssProp}
+            />
+          ))}
       </S.FollowCatBox>
       <S.FeedBox>
-        {feedsDummyData.feed.map(item => {
-          return (
-            <S.FeedItem key={item.feedId}>
-              <Image src={item.image} />
-              <SvgButton icon="HeartIcon" cssProp={SvgButtonCssProp} />
-            </S.FeedItem>
-          )
-        })}
+        {feed &&
+          feed.map(item => {
+            return (
+              <S.FeedItem key={item.feedId}>
+                <Image src={item.image} />
+                <SvgButton icon="HeartIcon" cssProp={SvgButtonCssProp} />
+              </S.FeedItem>
+            )
+          })}
       </S.FeedBox>
     </S.FeedsLayout>
   )

--- a/client/src/redux/actions/FeedsAction.ts
+++ b/client/src/redux/actions/FeedsAction.ts
@@ -1,0 +1,27 @@
+import { createAsyncThunk } from '@reduxjs/toolkit'
+import { axiosInstance } from '@Utils/instance'
+import { FEED_PATH } from '@Routes/feed.routes'
+import { Feeds } from '@Types/feed'
+import { CreateAsyncThunkTypes } from '../store'
+
+export const getFeedsAsync = createAsyncThunk<
+  Feeds,
+  undefined,
+  CreateAsyncThunkTypes
+>('feeds/getFeedsAsync', async (_, thunkAPI) => {
+  try {
+    // thunkAPI.getState()로 현재 state값을 조회할 수 있습니다.
+    const { page, pageSize } = thunkAPI.getState().feeds
+    const { data } = await axiosInstance.get(
+      `/${FEED_PATH}?page=${page}&size=${pageSize}`,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+        },
+      },
+    )
+    return data
+  } catch (error: any) {
+    return thunkAPI.rejectWithValue(error.message)
+  }
+})

--- a/client/src/redux/reducers/FeedSlice.ts
+++ b/client/src/redux/reducers/FeedSlice.ts
@@ -1,0 +1,40 @@
+import { createSlice, Reducer } from '@reduxjs/toolkit'
+import { Feeds } from '@Types/feed'
+import { getFeedsAsync } from '../actions/FeedsAction'
+
+const initialState: Feeds = {
+  feed: [],
+  follow: [],
+  page: 1,
+  pageSize: 10,
+  totalElements: 0,
+  totalPages: 0,
+  hasMoreFeed: true,
+  isLoading: false,
+}
+
+const userSlice = createSlice({
+  name: 'feeds',
+  initialState,
+  reducers: {},
+  extraReducers: builder => {
+    builder
+      // 전체 피드 불러오기
+      .addCase(getFeedsAsync.pending, state => {
+        state.isLoading = true
+      })
+      .addCase(getFeedsAsync.fulfilled, (state, { payload }) => {
+        const { feed, follow } = payload
+        state.isLoading = false
+        state.feed = feed
+        state.follow = follow
+        state.totalElements = payload.totalElements
+        state.totalPages = payload.totalPages
+      })
+      .addCase(getFeedsAsync.rejected, () => {
+        alert('피드를 불러오는 데 실패했습니다:(')
+      })
+  },
+})
+
+export const feedsReducer: Reducer<typeof initialState> = userSlice.reducer

--- a/client/src/redux/store/index.ts
+++ b/client/src/redux/store/index.ts
@@ -4,12 +4,13 @@ import {
   PreloadedState,
 } from '@reduxjs/toolkit'
 import { useDispatch, useSelector, TypedUseSelectorHook } from 'react-redux'
-
 import { userReducer } from '../reducers/userSlice'
+import { feedsReducer } from '../reducers/FeedSlice'
 
 const rootReducer = combineReducers({
   /* 슬라이스로 생성한 리듀서는 여기에 추가하면 됩니다. */
   user: userReducer,
+  feeds: feedsReducer,
 })
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {


### PR DESCRIPTION
## 주요 변경 사항
- 더미데이터를 생성해 냥이생활 전체 피드 페이지에 렌더링했습니다.
- 이후 실제로 서버에 데이터를 요청해 페이지에 렌더링했습니다.

## 코드 변경 이유
## 코드 리뷰 시 중점적으로 봐야할 부분
- 서버에 데이터를 요청하고 이를 state로 관리하기 위해 redux 폴더에 ``feedsActions.ts``와 ``feedsSlice.ts``를 생성했습니다.

### 비동기 함수 정의
- 서버에 전체 피드 데이터를 불러오는 함수 ``getFeedsAsync``를 정의했습니다.
- 데이터를 요청할 때 page와 size를 쿼리스트링으로 필수로 전달하도록 구현되어있습니다.
- 따라서 현재 state의 page와 size를 가져오기 위해 ``thunkAPI.getState``를 사용했습니다.
```ts
// src/redux/actions/FeedsAction.ts

export const getFeedsAsync = createAsyncThunk<
  Feeds,
  undefined,
  CreateAsyncThunkTypes
>('feeds/getFeedsAsync', async (_, thunkAPI) => {
  try {
    // thunkAPI.getState()로 현재 state값을 조회할 수 있습니다.
    // feedsSlice.ts 파일에 정의되어있는 feeds라는 슬라이스에 접근해 state를 조회하고, 그 중 page와 pazeSize를 가져와 변수로 사용합니다.
    const { page, pageSize } = thunkAPI.getState().feeds
    
    // axios를 사용하면 데이터는 response.data와 같이 data라는 객체에 저장되기 때문에 
    // 구조 분해 할당을 통해 response.data가 아닌 data로 바로 사용할 수 있도록 선언했습니다.
    const { data } = await axiosInstance.get(
    
     // 구조 분해 할당으로 선언한 page와 pazeSize를 요청 쿼리스트링으로 전달합니다.
      `/${FEED_PATH}?page=${page}&size=${pageSize}`,
      
      // 전체 피드 데이터 요청에 authorization이 필요하므로 헤더에 액세스 토큰을 실어 함께 요청합니다.
      {
        headers: {
          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
        },
      },
    )
   // 요청으로 받아온 응답 데이터를 리턴합니다.
    return data
  } catch (error: any) {
    return thunkAPI.rejectWithValue(error.message)
  }
})
```

### 비동기 로직 처리 결과에 따른 리듀서 작성
- ``getFeedsAsync``함수 호출 결과에 따라 서로 다른 로직을 처리하도록 합니다.

```ts
// src/redux/reducers/feedsSlice.ts

// 피드와 관련된 데이터를 state로 관리합니다. 
// 피드 데이터 초기값
const initialState: Feeds = {
  feed: [],
  follow: [],
  page: 1,
  pageSize: 10,
  totalElements: 0,
  totalPages: 0,
  hasMoreFeed: true,
  isLoading: false,
}

const userSlice = createSlice({
 /* 중략 */
  extraReducers: builder => {
    builder
      // 전체 피드 불러오기
      .addCase(getFeedsAsync.pending, state => {
        state.isLoading = true
      })
       // getFeedsAsync 함수 호출로 리턴된 값이 payload로 전달됩니다.
      .addCase(getFeedsAsync.fulfilled, (state, { payload }) => {
        // 객체 구조 분해 할당으로 변수를 선언합니다. totalElements와 totalPages도 가능합니다.
        const { feed, follow } = payload
        state.isLoading = false
        state.feed = feed
        state.follow = follow
        state.totalElements = payload.totalElements
        state.totalPages = payload.totalPages
      })
      .addCase(getFeedsAsync.rejected, () => {
        alert('피드를 불러오는 데 실패했습니다:(')
      })
  },
})

```

### dispatch 하기
- 냥이생활 페이지로 이동하자마자 데이터를 불러와 렌더링해야 합니다.
- 따라서 useEffect Hook을 이용해 처음 페이지 컴포넌트가 렌더링 될 때 요청을 보내도록 했습니다.
```tsx
  const dispatch = useAppDispatch()
  const { feed, follow } = useAppSelector(state => state.feeds)

  useEffect(() => {
    // dispatch에 getFeedsAsyns 함수를 전달해 호출합니다.
    dispatch(getFeedsAsync())
    // 리액트에서 dispatch는 변하지 않기 때문에 생략해도 무방합니다.
     }, [dispatch])
```
## 연결된 이슈
#233 

## 자료 (스크린샷 등)

### 더미데이터로 렌더링
![냥이생활전체피드](https://user-images.githubusercontent.com/88873956/193852949-4384f913-dde7-4abd-839d-bc0c0d29eefb.gif)

### 실제 데이터 요청 후 렌더링
![feeds-page](https://user-images.githubusercontent.com/88873956/193854632-79d4df58-18c5-44ed-b13f-c89ba64b1b8e.gif)
