### PR TITLE
fix: 냥이생활 특정 피드 보기에 변수 수정 및 피드 반환 데이터에 좋아요 데이터 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
@@ -92,4 +92,8 @@ public class LikeService {
 
         likeRepository.deleteByUserAndBoardComment(user, boardComment);
     }
+
+    public boolean findExistLike(Feed feed, User user) {
+        return likeRepository.existsByUserAndFeed(user, feed);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -81,10 +81,11 @@ public class FeedController {
             })
     @GetMapping("/{feeds-id}")
     public ResponseEntity getFeed(@PathVariable("feeds-id") @Positive long feedId) {
-        Feed feed = feedService.findFeed(feedId);
-        List<FeedTag> feedTags = feedTagService.findFeedTags(feed);
-        List<FeedComment> comments = feedCommentService.findComments(feed);
-        FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(feed);
+        Feed findFeed = feedService.findFeed(feedId);
+        List<FeedTag> feedTags = feedTagService.findFeedTags(findFeed);
+        List<FeedComment> comments = feedCommentService.findComments(findFeed);
+
+        FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(findFeed);
         response.setTags(feedTagMapper.feedTagsToFeedTagDtos(feedTags));
         response.setComments(feedCommentMapper.feedCommentsToFeedCommentGetDtos(comments));
         return new ResponseEntity<>(response, HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -11,6 +11,7 @@ import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
 import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
+import com.twentyfour_seven.catvillage.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -80,14 +81,23 @@ public class FeedController {
                     @ApiResponse(responseCode = "404", description = "존재하지 않는 냥이생활 피드")
             })
     @GetMapping("/{feeds-id}")
-    public ResponseEntity getFeed(@PathVariable("feeds-id") @Positive long feedId) {
+    public ResponseEntity getFeed(@PathVariable("feeds-id") @Positive long feedId,
+                                  @AuthenticationPrincipal User user) {
         Feed findFeed = feedService.findFeed(feedId);
         List<FeedTag> feedTags = feedTagService.findFeedTags(findFeed);
         List<FeedComment> comments = feedCommentService.findComments(findFeed);
 
         FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(findFeed);
+
+        // 로그인되어 있다면 유저가 해당 피드에 좋아요를 눌렀는지 확인
+        if (user != null) {
+            boolean isLike = feedService.feedIsLike(findFeed, user.getUsername());
+            response.setIsLike(isLike);
+        }
+
         response.setTags(feedTagMapper.feedTagsToFeedTagDtos(feedTags));
         response.setComments(feedCommentMapper.feedCommentsToFeedCommentGetDtos(comments));
+
         return new ResponseEntity<>(response, HttpStatus.OK);
     }
 
@@ -100,21 +110,29 @@ public class FeedController {
                                    @RequestParam @Positive int size,
                                    @AuthenticationPrincipal User user) {
         // page 와 size 정보를 토대로 Page 생성
-        Page<Feed> feeds = feedService.findFeeds(page - 1, size);
+        Page<Feed> feedPage = feedService.findFeeds(page - 1, size);
+
+        String email = null;
+        if (user != null) {
+            email = user.getUsername();
+        }
+
+        // feed, userId로 feed dto 리스트로 반환
+        List<FeedMultiGetResponseDto> feedResponseDtos =
+                feedMapper.feedsToFeedMultiGetResponseDtos(feedPage.getContent(), email);
 
         // Page 의 feed 컨텐츠를 형식에 맞는 Dto 로 매핑
-        List<FeedMultiGetResponseDto> feedResponseDto = feedMapper.feedsToFeedMultiGetResponseDtos(feeds.getContent());
 
-        // TODO: Like 구현 후 로그인한 유저가 글마다 좋아요를 눌렀는지 여부 feedResponseDto 에 반영 로직 필요 !
 
         // 응답 객체 생성
-        FeedMultiResponseDto response = new FeedMultiResponseDto(feedResponseDto, feeds);
+        FeedMultiResponseDto response = new FeedMultiResponseDto(feedResponseDtos, feedPage);
 
         // 로그인 정보가 있다면 유저가 팔로우한 유저의 고양이 정보 가져오기
         if (user != null) {
-            List<FollowFeedGetDto> follows = feedService.findFollows(user).stream().map(
+            List<FollowFeedGetDto> follows = feedService.findFollows(email).stream().map(
                     cat -> new FollowFeedGetDto(cat.getImage(), cat.getCatId())
             ).collect(Collectors.toList());
+
             response.setFollow(follows);
         }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedCommentGetDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedCommentGetDto.java
@@ -9,9 +9,10 @@ import lombok.*;
 @AllArgsConstructor
 public class FeedCommentGetDto {
     private long feedCommentId;
-    private long feedId;
     private Long userId;
     private Long catId;
+    private String profileImage;
+    private String name;
     private String body;
     private long likeCount;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
@@ -12,22 +12,23 @@ import java.util.List;
 public class FeedGetResponseDto {
     private long feedId;
     private long catId;
+    private String name;
+    private String profileImage;
     private List<PictureDto> pictures;
     private String body;
     private long likeCount;
-    private long viewCount;
     private long commentCount;
     private List<FeedTagDto> tags;
     private List<FeedCommentGetDto> comments;
 
     @Builder
-
-    public FeedGetResponseDto(long feedId, long catId, String body, long likeCount, long viewCount, long commentCount) {
+    public FeedGetResponseDto(long feedId, long catId, String name, String profileImage, String body, long likeCount, long commentCount) {
         this.feedId = feedId;
         this.catId = catId;
+        this.name = name;
+        this.profileImage = profileImage;
         this.body = body;
         this.likeCount = likeCount;
-        this.viewCount = viewCount;
         this.commentCount = commentCount;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
@@ -1,6 +1,7 @@
 package com.twentyfour_seven.catvillage.feed.dto;
 
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
+import io.swagger.annotations.ApiParam;
 import lombok.*;
 
 import java.util.List;
@@ -10,26 +11,40 @@ import java.util.List;
 @NoArgsConstructor
 @AllArgsConstructor
 public class FeedGetResponseDto {
+    @ApiParam(value = "냥이생활 피드 식별자(id)", example = "1")
     private long feedId;
+
+    @ApiParam(value = "피드 작성한 고양이 식별자(id)", example = "1")
     private long catId;
+
+    @ApiParam(value = "피드 작성한 고양이 이름", example = "수라")
     private String name;
+
+    @ApiParam(value = "피드 작성한 고양이 프로필 이미지 경로", example = "https://image.catvillage.shop.s3.ap-northeast-2.amazonaws.com/catvillage/images/9f39a517-3555-47b1-a0d4-344e73af1d0b-feed-image-1.jpg")
     private String profileImage;
+
     private List<PictureDto> pictures;
+
+    @ApiParam(value = "요청을 보낸 사용자가 피드에 좋아요를 눌렀는지 여부, 좋아요를 추가했을 경우 true", example = "false")
+    private Boolean isLike;
+
+    @ApiParam(value = "피드에 작성한 글", example = "수라는 잠이 많아요")
     private String body;
+
+    @ApiParam(value = "피드 좋아요 개수", example = "30")
     private long likeCount;
-    private long commentCount;
+
     private List<FeedTagDto> tags;
     private List<FeedCommentGetDto> comments;
 
     @Builder
-    public FeedGetResponseDto(long feedId, long catId, String name, String profileImage, String body, long likeCount, long commentCount) {
+    public FeedGetResponseDto(long feedId, long catId, String name, String profileImage, String body, long likeCount) {
         this.feedId = feedId;
         this.catId = catId;
         this.name = name;
         this.profileImage = profileImage;
         this.body = body;
         this.likeCount = likeCount;
-        this.commentCount = commentCount;
     }
 }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
@@ -16,7 +16,7 @@ public class FeedMultiGetResponseDto {
     @ApiParam(value = "특정 피드의 대표이미지")
     private String image;
     @ApiParam(value = "로그인한 사용자가 좋아요를 눌렀는지 여부")
-    private boolean isLike;
+    private Boolean isLike;
 
     public FeedMultiGetResponseDto(long feedId, String image) {
         this.feedId = feedId;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedCommentMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedCommentMapper.java
@@ -18,10 +18,13 @@ public interface FeedCommentMapper {
         if (feedComment == null) {
             return null;
         }
+
+        // 유저 프로필로 작성한 경우와 고양이 프로필로 작성한 경우 분리
         if (feedComment.getCat() == null) {
             return FeedCommentGetDto.builder()
                     .feedCommentId(feedComment.getFeedCommentId())
-                    .feedId(feedComment.getFeed().getFeedId())
+                    .profileImage(feedComment.getUser().getProfileImage())
+                    .name(feedComment.getUser().getName())
                     .userId(feedComment.getUser().getUserId())
                     .catId(null)
                     .body(feedComment.getBody())
@@ -29,7 +32,8 @@ public interface FeedCommentMapper {
         } else {
             return FeedCommentGetDto.builder()
                     .feedCommentId(feedComment.getFeedCommentId())
-                    .feedId(feedComment.getFeed().getFeedId())
+                    .name(feedComment.getCat().getName())
+                    .profileImage(feedComment.getCat().getImage())
                     .userId(null)
                     .catId(feedComment.getCat().getCatId())
                     .body(feedComment.getBody())

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -52,9 +52,10 @@ public interface FeedMapper {
         return FeedGetResponseDto.builder()
                 .feedId(feed.getFeedId())
                 .catId(feed.getCat().getCatId())
+                .name(feed.getCat().getName())
+                .profileImage(feed.getCat().getImage())
                 .body(feed.getBody())
                 .likeCount(feed.getLikeCount())
-                .viewCount(feed.getViewCount())
                 .commentCount(feed.getCommentCount())
                 .build();
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -12,6 +12,7 @@ import org.mapstruct.ReportingPolicy;
 import org.springframework.data.domain.Page;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
@@ -56,19 +57,40 @@ public interface FeedMapper {
                 .profileImage(feed.getCat().getImage())
                 .body(feed.getBody())
                 .likeCount(feed.getLikeCount())
-                .commentCount(feed.getCommentCount())
                 .build();
     }
 
     List<FeedGetResponseDto> feedsToFeedGetResponseDtos(List<Feed> feeds);
 
-    default FeedMultiGetResponseDto feedToFeedMultiGetResponseDto(Feed feed) {
+    default FeedMultiGetResponseDto feedToFeedMultiGetResponseDto(Feed feed, String email) {
         FeedMultiGetResponseDto feedMultiGetResponseDto =  new FeedMultiGetResponseDto();
         feedMultiGetResponseDto.setFeedId(feed.getFeedId());
+
+        // 사진 리스트에서 첫번쨰 사진 가져와서 대표사진으로 저장
         if(!feed.getPictures().isEmpty()) {
             feedMultiGetResponseDto.setImage(feed.getPictures().get(0).getPath());
         }
+
+        // 피드마다 좋아요 여부 저장
+        boolean isLike = false;
+        if (email != null) {
+            isLike = feed.getLikes().stream().anyMatch(like -> like.getUser().getEmail().equals(email));
+        }
+        feedMultiGetResponseDto.setIsLike(isLike);
+
         return feedMultiGetResponseDto;
     }
-    List<FeedMultiGetResponseDto> feedsToFeedMultiGetResponseDtos(List<Feed> feeds);
+    default List<FeedMultiGetResponseDto> feedsToFeedMultiGetResponseDtos(List<Feed> feeds, String email) {
+        if (feeds == null) {
+            return null;
+        }
+
+        List<FeedMultiGetResponseDto> list = new ArrayList<>();
+
+        for (Feed feed : feeds) {
+            list.add(feedToFeedMultiGetResponseDto(feed, email));
+        }
+
+        return list;
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -88,8 +88,8 @@ public class FeedService {
         return feedRepository.findAll(pageRequest);
     }
 
-    public List<Cat> findFollows(org.springframework.security.core.userdetails.User user) {
-        User loginUser = userService.findVerifiedEmail(user.getUsername());
+    public List<Cat> findFollows(String email) {
+        User loginUser = userService.findVerifiedEmail(email);
         List<User> followUsers = followService.findFollowsInFeed(loginUser);
         List<Cat> followCats = new ArrayList<>();
         followUsers.forEach(
@@ -175,5 +175,10 @@ public class FeedService {
         // feed 에 likeCount 1 빼서 저장
         findFeed.setLikeCount(findFeed.getLikeCount() - 1);
         feedRepository.save(findFeed);
+    }
+
+    public boolean feedIsLike(Feed feed, String email) {
+        User findUser = userService.findVerifiedEmail(email);
+        return likeService.findExistLike(feed, findUser);
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- get-feed. get-feeds 요청에 응답 데이터 수정(viewCount 제거, name 추가, profileImage 추가)
- get-feed, get-feeds 요청에 like 담도록 로직 변경

## 코드 변경 이유
- 피드 페이지에서 조회수 데이터는 사용하지 않아 피드 응답데이터에서 제거했습니다.
- 피드 페이지에 작성자 정보가 필요하여 작성자 이름과 프로필 이미지 정보 추가했습니다.
- 피드 가져오기 요청 시 로그인된 상태라면 좋아요 눌렀는지 여부가 필요하여 코드 추가했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- feedController에 getFeed, getFeeds 로직 올바른지
- feedMapper
- feed 반환 dto 들

## 연결된 이슈
close #236 

## 자료 (스크린샷 등)
