### PR TITLE
fix: local test를 위한 cors origin 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/CorsConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/CorsConfig.java
@@ -15,6 +15,7 @@ public class CorsConfig {
         UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
         CorsConfiguration config = new CorsConfiguration();
         config.setAllowCredentials(true);   // json을 자바스크립트에서 처리할 수 있음
+        config.addAllowedOrigin("http://localhost:3000");
         config.addAllowedOrigin("https://catvillage.shop");
 //        config.addAllowedOriginPattern("https://*.catvillage.shop:[*]");
         config.addAllowedHeader("*");


### PR DESCRIPTION
## 주요 변경 사항
- `http://localhost:3000`에 대한 cors origin 허용

## 코드 변경 이유
- 프론트엔드 로컬 테스트 환경 구축을 위한 cors origin 추가

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈

## 자료 (스크린샷 등)
