### PR TITLE
fix: 이미지 저장용 S3 버킷 이동으로 버킷 이름 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
@@ -14,7 +14,7 @@ import java.util.UUID;
 @Service
 public class S3UploadService {
 
-    private static final int CAPACITY_LIMIT_BYTE = 4194304;
+    private static final int CAPACITY_LIMIT_BYTE = 1024 * 1024 * 4;
 
     @Value("${cloud.aws.s3.bucket}")
     private String bucket;
@@ -29,7 +29,7 @@ public class S3UploadService {
         String s3FileName = filePath + UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
         // 파일의 크기가 용량제한을 넘을 시 예외를 던진다.
-        if (multipartFile.getInputStream().available() > CAPACITY_LIMIT_BYTE) {
+        if (multipartFile.getSize() > CAPACITY_LIMIT_BYTE) {
             throw new RuntimeException("이미지가 4M 제한을 넘어갑니다.");
         }
         // S3에 알려줄 파일 메타 데이터 정보에 파일 크기를 담는다.

--- a/server/catvillage/src/main/resources/application-common.yml
+++ b/server/catvillage/src/main/resources/application-common.yml
@@ -21,10 +21,13 @@ spring:
             token-uri: https://kauth.kakao.com/oauth/token
             user-info-uri: https://kapi.kakao.com/v2/user/me
             user-name-attribute: id
+  servlet:
+    multipart:
+      maxFileSize: 5MB
 cloud:
   aws:
     s3:
-      bucket: image.catvillage.shop
+      bucket: catvillage-image-server
       dir: catvillage/images/
     region:
       static: ap-northeast-2


### PR DESCRIPTION
## 주요 변경 사항
- S3 버킷 이름 수정
- spring에 MultipartFile에 용량제한 기본값인 1MB로 되어있어서 5MB로 설정 변경

## 코드 변경 이유
- S3 버킷에 온점 들어가면 https 적용이 정상적으로 되지 않아 브라우저에 사진 렌더링 실패하는 문제가 있어 버킷 새로 생성
- 버킷 이름 바뀌면서 버킷 이름 환경변수 수정
- 이미지 업로드 시 1M 이상이면 FileSizeLimitExceededException 파일 사이즈 제한 초과 예외 발생 하여 MultipartFile 용량제한 5MB로 변경, 서비스 로직에서 검증할 때는 4MB

## 코드 리뷰 시 중점적으로 봐야할 부분
- application.yml
- S3UploadService

## 연결된 이슈
#241 

## 자료 (스크린샷 등)
