### PR TITLE
fix: 유저 정보 변경 시 기본 프로필 이미지 설정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
@@ -65,11 +65,14 @@ public interface UserMapper {
         if (requestBody == null) {
             return null;
         } else {
+            String profileImage = requestBody.getProfileImage().isEmpty() ?
+                    "https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/catvillage/images/252c5f03-4c0a-4f2a-8874-b928e7dde911-default-user-image.png" :
+                    requestBody.getProfileImage();
             return User.builder()
                     .password(requestBody.getPassword())
                     .name(requestBody.getName())
                     .location(requestBody.getLocation())
-                    .profileImage(requestBody.getProfileImage())
+                    .profileImage(profileImage)
                     .build();
         }
     }


### PR DESCRIPTION
## 주요 변경 사항
- profileImage가 null로 들어올 경우 기본 프로필 이미지로 저장

## 코드 변경 이유
- 프로필 이미지가 null로 들어올 경우 페이지에서 깨지기 때문에 S3에 업로드한 기본 프로필 이미지로 저장하게끔 수정했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분


## 연결된 이슈


## 자료 (스크린샷 등)
