### PR TITLE
fix: 냥이생활 특정 피드 가져오기 요청에 pictures null로 반환되는 오류 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -50,7 +50,17 @@ public interface FeedMapper {
         if (feed == null) {
             return null;
         }
-        return FeedGetResponseDto.builder()
+
+        List<PictureDto> pictureDtos = new ArrayList<>();
+
+        // picture가 있다면 pictureDto로 변환
+        if(!feed.getPictures().isEmpty()) {
+            feed.getPictures().stream().forEach(picture -> {
+                pictureDtos.add(new PictureDto(picture));
+            });
+        }
+
+         FeedGetResponseDto feedGetResponseDto = FeedGetResponseDto.builder()
                 .feedId(feed.getFeedId())
                 .catId(feed.getCat().getCatId())
                 .name(feed.getCat().getName())
@@ -58,6 +68,8 @@ public interface FeedMapper {
                 .body(feed.getBody())
                 .likeCount(feed.getLikeCount())
                 .build();
+        feedGetResponseDto.setPictures(pictureDtos);
+        return feedGetResponseDto;
     }
 
     List<FeedGetResponseDto> feedsToFeedGetResponseDtos(List<Feed> feeds);


### PR DESCRIPTION
## 주요 변경 사항
- FeedMapper에 feedToFeedGetResponseDto에 pictures 값 매핑해주는 로직 빠져있어서 추가

## 코드 변경 이유
- Get-feed 요청 시 pictures 리스트가 null로 반환되는 문제가 있어서 feed의 pictures 값을 매핑해주는 로직 추가했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 로직이 맞는지만 확인해주시면 됩니다!

## 연결된 이슈
close #252 

## 자료 (스크린샷 등)
