### PR TITLE
fix: 냥이생활 피드 수정하기 시 사진 저장되지 않는 오류 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -15,6 +15,7 @@ import com.twentyfour_seven.catvillage.user.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
+import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -134,7 +135,8 @@ public class FeedService {
         feed.getPictures().forEach(
                 picture -> {
                     if (!picturePaths2.contains(picture.getPath())) {
-                        findFeed.getPictures().add(pictureService.createPicture(picture));
+                        Picture createPicture = Picture.builder().feed(findFeed).path(picture.getPath()).build();
+                        findFeed.getPictures().add(pictureService.createPicture(createPicture));
                     }
                 }
         );


### PR DESCRIPTION
## 주요 변경 사항
- 이미지 업데이트 하는 부분에서 추가된 이미지는 Picture 생성하여 feed, path 할당 후 PictureSerivce에 저장하는 메서드 호출하도록 변경

## 코드 변경 이유
- picture 업데이트 시 feed가 할당되지 않은 상태로 저장되어 picture에 feed가 null 값으로 저장되었습니다.
- 그래서 get-feed 요청 시 picture가 누락된 상태로 전달되었습니다.
- picture에 feed 할당 후 저장하도록 변경했습니다.
- 로컬에서 정상적으로 되는지 테스트도 완료했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분


## 연결된 이슈

## 자료 (스크린샷 등)
