### PR TITLE
fix: 집사생활 조회 시 사진 로직 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -66,7 +66,7 @@ public interface BoardMapper {
                     .tags(board.getTagToBoards().stream()
                             .map(e -> new BoardTagDto(e.getBoardTag()))
                             .collect(Collectors.toList()))
-                    .picture(board.getPictures().isEmpty() ? "" : board.getPictures().get(0).getPath())
+                    .picture(board.getPictures() == null ? "" : board.getPictures().get(0).getPath())
                     .viewCount(board.getViewCount())
                     .likeCount(board.getLikeCount())
                     .commentCount(board.getCommentCount())
@@ -89,7 +89,7 @@ public interface BoardMapper {
                     .tags(board.getTagToBoards().stream()
                             .map(e -> new BoardTagDto(e.getBoardTag()))
                             .collect(Collectors.toList()))
-                    .pictures(board.getPictures().isEmpty() ? new ArrayList<>() :
+                    .pictures(board.getPictures() == null ? new ArrayList<>() :
                             board.getPictures().stream()
                                     .map(PictureDto::new)
                                     .collect(Collectors.toList()))


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활 조회 mapper 동작에서 pictures에 `isEmpty()` 대신 null 체크로 변경

## 코드 변경 이유
- `isEmpty()`의 경우 null을 만나면 `NullPointerException(NPE)`이 발생하기 때문에 null 체크로 변경

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈

## 자료 (스크린샷 등)
