### PR TITLE
feat: app layout을 발표용 layout으로 변경

### DIFF
--- a/client/src/layout/DashBoard.tsx
+++ b/client/src/layout/DashBoard.tsx
@@ -13,6 +13,10 @@ const NavBar = styled.nav`
   gap: 5px;
 `
 
+const BorderBox = styled.div`
+  border: 3px solid black;
+`
+
 const DashBoardLayout = styled.div`
   width: 100vw;
   height: 100vh;
@@ -48,10 +52,13 @@ const DashBoard = () => {
         <Link to={FEED_PATH}>feed</Link>
         <Link to={BOARD_PATH}>Board</Link>
       </NavBar>
-      <PhoneLayout>
-        <Outlet />
-      </PhoneLayout>
+      <BorderBox>
+        <PhoneLayout>
+          <Outlet />
+        </PhoneLayout>
+      </BorderBox>
     </DashBoardLayout>
   )
 }
+
 export default DashBoard

--- a/client/src/layout/PhoneLayout.tsx
+++ b/client/src/layout/PhoneLayout.tsx
@@ -20,7 +20,6 @@ const phoneSize = {
 const PhoneBox = styled.div<{ cssProp?: CSSProp }>(
   ({ cssProp }) => css`
     position: relative;
-    border: 3px solid black;
     width: 100%;
     height: 100%;
     overflow: scroll;

--- a/client/src/layout/PhoneLayout.tsx
+++ b/client/src/layout/PhoneLayout.tsx
@@ -41,15 +41,15 @@ const phoneLayout = (cssProp: CSSProp) =>
     )
   }
 
-export const Iphone11Pro: FC<{ children: JSX.Element }> = phoneLayout(
+export const Iphone11Pro: FC<{ children?: JSX.Element }> = phoneLayout(
   css(phoneSize.Iphone11Pro),
 )
 
-export const Iphone11Max: FC<{ children: JSX.Element }> = phoneLayout(
+export const Iphone11Max: FC<{ children?: JSX.Element }> = phoneLayout(
   css(phoneSize.Iphone11ProMax),
 )
 
-export const IphoneSE: FC<{ children: JSX.Element }> = phoneLayout(
+export const IphoneSE: FC<{ children?: JSX.Element }> = phoneLayout(
   css(phoneSize.IphoneSE),
 )
 
@@ -61,7 +61,7 @@ const CustomPhoneLayout = styled.div`
   overflow: auto;
 `
 
-export const CustomPhone: FC<{ children: JSX.Element }> = () => {
+export const CustomPhone: FC<{ children?: JSX.Element }> = () => {
   return (
     <CustomPhoneLayout>
       <PhoneBox>

--- a/client/src/layout/PresentLayout.tsx
+++ b/client/src/layout/PresentLayout.tsx
@@ -1,0 +1,32 @@
+import { Outlet } from 'react-router-dom'
+import styled from 'styled-components'
+import * as phoneLayouts from './PhoneLayout'
+
+const BorderBox = styled.div`
+  border-radius: 10px;
+  box-shadow: rgba(0, 0, 0, 0.07) 0px 1px 2px, rgba(0, 0, 0, 0.07) 0px 2px 4px,
+    rgba(0, 0, 0, 0.07) 0px 4px 8px, rgba(0, 0, 0, 0.07) 0px 8px 16px,
+    rgba(0, 0, 0, 0.07) 0px 16px 32px, rgba(0, 0, 0, 0.07) 0px 32px 64px;
+`
+
+const DashBoardLayout = styled.div`
+  width: 100vw;
+  height: 100vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+`
+
+const PresentLayout = () => {
+  const PhoneLayout = phoneLayouts.Iphone11Pro
+  return (
+    <DashBoardLayout>
+      <BorderBox>
+        <PhoneLayout>
+          <Outlet />
+        </PhoneLayout>
+      </BorderBox>
+    </DashBoardLayout>
+  )
+}
+export default PresentLayout

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -1,4 +1,6 @@
 import DashBoard from '@Layout/DashBoard'
+import { Iphone11Pro } from '@Layout/PhoneLayout'
+import PresentLayout from '@Layout/PresentLayout'
 import Cat from '@pages/Cat'
 import Login from '@pages/Login'
 import Signup from '@pages/Signup'
@@ -10,7 +12,9 @@ import { mainRoutes } from './main.routes'
 
 const appRoutes: RouteObject = {
   path: '/',
-  element: <DashBoard />,
+  // element: <Iphone11Pro />,
+  // element: <DashBoard />,
+  element: <PresentLayout />,
   children: [
     { path: 'cat', element: <Cat /> },
     mainRoutes,


### PR DESCRIPTION
## 주요 변경 사항
개발 과정에서 사용했던 레이아웃인 DsahBoard 대신 PresentLayout을 제작하고 대체하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
boxshadow을 줘 화면의 경계를 나타내고 화면 가운데 정렬을 하였습니다

## 연결된 이슈

## 자료 (스크린샷 등)

<img width="404" alt="스크린샷 2022-10-06 오후 1 25 01" src="https://user-images.githubusercontent.com/96106122/194216071-00ec1249-a432-4f23-b98d-86cafd0b123a.png">
