### PR TITLE
feat: 고양이 프로필 기본 이미지 자동 할당

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
@@ -15,6 +15,9 @@ public interface CatMapper {
         if (catPostDto == null) {
             return null;
         }
+        String profileImage = (catPostDto.getImage() == null || catPostDto.getImage().isEmpty()) ?
+                "https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/catvillage/images/1ba41d17-5e93-4926-812a-6072e90b7b5b-default-cat-profile.png" :
+                catPostDto.getImage();
         LocalDateTime birthDate = LocalDateTime.of(catPostDto.getBirthYear(), catPostDto.getBirthMonth(), catPostDto.getBirthDay(), 0, 0, 0);
         Cat cat = Cat.builder()
                 .name(catPostDto.getName())
@@ -22,7 +25,7 @@ public interface CatMapper {
                 .sex(catPostDto.getSex())
                 .weight(catPostDto.getWeight())
                 .body(catPostDto.getBody())
-                .image(catPostDto.getImage())
+                .image(profileImage)
                 .build();
         return cat;
     }


### PR DESCRIPTION
## 주요 변경 사항
- catMapper에 catPostDtoToCat에 기본이미지 자동 저장 로직 추가
- 고양이 등록, 수정 요청 시 프로필 이미지가 null 또는 빈 문자열로 입력될 경우 이미지 서버에 저장된 기본 이미지로 저장

## 코드 변경 이유
- 유저가 고양이 프로필에 프로필 이미지를 등록하지 않을 경우 디폴트 이미지로 자동 설정하도록 구현했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- catPostDtoToCat

## 연결된 이슈

## 자료 (스크린샷 등)
