### PR TITLE
fix: 집사생활 댓글 반환 데이터 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/comment/BoardCommentResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/comment/BoardCommentResponseDto.java
@@ -15,18 +15,20 @@ public class BoardCommentResponseDto {
     private Long boardCommentId;
     private String body;
     private String name;
+    private String profileImage;
     private String link;
     private Long likeCount;
-    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
-    private LocalDateTime createdDate;
+    // 생성일을 사용하지 않아 주석처리
+//    @JsonFormat(pattern = "yyyy-MM-dd HH:mm:ss")
+//    private LocalDateTime createdDate;
 
     @Builder
-    public BoardCommentResponseDto(Long boardCommentId, String body, String name, String link, Long likeCount, LocalDateTime createdDate) {
+    public BoardCommentResponseDto(Long boardCommentId, String body, String name, String profileImage, String link, Long likeCount) {
         this.boardCommentId = boardCommentId;
         this.body = body;
         this.name = name;
+        this.profileImage = profileImage;
         this.link = link;
         this.likeCount = likeCount;
-        this.createdDate = createdDate;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardCommentMapper.java
@@ -34,9 +34,10 @@ public interface BoardCommentMapper {
                     .boardCommentId(boardComment.getBoardCommentId())
                     .body(boardComment.getBody())
                     .name(boardComment.getUser().getName())
+                    .profileImage(boardComment.getUser().getProfileImage())
                     .link("https://catvillage.tk/users/" + boardComment.getUser().getUserId())
                     .likeCount(boardComment.getLikeCount())
-                    .createdDate(boardComment.getCreatedDate())
+//                    .createdDate(boardComment.getCreatedDate())
                     .build();
         }
     }


### PR DESCRIPTION
## 주요 변경 사항 
- 사용하지 않는 생성일 데이터 제거
- 누락되었던 profileImage 데이터 추가

## 코드 변경 이유
- 집사생활 댓글 표현 시 필요한 데이터 누락으로 추가
- 집사생활 댓글 표현 시 필요 없는 데이터가 존재하여 제거

## 코드 리뷰 시 중점적으로 봐야할 부분
- BoardCommentResponseDto class
  - profileImage 항목 추가
  - createdDate 제거
- BoardCommentMapper interface
  - 추가 및 제거된 항목에 대한 로직이 올바른지

## 연결된 이슈
fixed #265

## 자료 (스크린샷 등)
