### PR TITLE
fix: user 테이블 칼럼 추가로 엔티티에 변수 추가 및 유저 프로필 페이지에 필요한 dto 생성

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatResponseDto.java
@@ -8,6 +8,7 @@ import java.util.List;
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class CatResponseDto {
     long catId;
     String name;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatSimpleDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/dto/CatSimpleDto.java
@@ -1,0 +1,16 @@
+package com.twentyfour_seven.catvillage.cat.dto;
+
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class CatSimpleDto {
+    private String profileImage;
+    private String name;
+    @ApiModelProperty(value = "고양이 프로필 링크")
+    private String link;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/mapper/CatMapper.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.cat.mapper;
 
+import com.twentyfour_seven.catvillage.cat.dto.CatSimpleDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatPostDto;
 import com.twentyfour_seven.catvillage.cat.dto.CatResponseDto;
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
@@ -8,6 +9,7 @@ import org.mapstruct.ReportingPolicy;
 
 import java.time.LocalDateTime;
 import java.util.ArrayList;
+import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CatMapper {
@@ -47,4 +49,17 @@ public interface CatMapper {
         );
         return catResponseDto;
     }
+
+    default CatSimpleDto catToCatGetUserResponseDto(Cat cat) {
+        if (cat == null) {
+            return null;
+        }
+
+        return CatSimpleDto.builder()
+                .profileImage(cat.getImage())
+                .name(cat.getName())
+                .link("https://catvillage.shop/cats/" + cat.getCatId())
+                .build();
+    }
+    List<CatSimpleDto> catsToCatGetUserResponseDtos(List<Cat> cats);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedSimpleDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedSimpleDto.java
@@ -1,0 +1,13 @@
+package com.twentyfour_seven.catvillage.feed.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class FeedSimpleDto {
+    private Long feedId;
+    private String picture;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -2,10 +2,7 @@ package com.twentyfour_seven.catvillage.feed.mapper;
 
 import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
-import com.twentyfour_seven.catvillage.feed.dto.FeedGetResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedMultiGetResponseDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedPostDto;
-import com.twentyfour_seven.catvillage.feed.dto.FeedResponseDto;
+import com.twentyfour_seven.catvillage.feed.dto.*;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
@@ -105,4 +102,16 @@ public interface FeedMapper {
 
         return list;
     }
+
+    default FeedSimpleDto feedToFeedSimpleDto(Feed feed) {
+        String picture = "";
+        if (feed.getPictures() != null && feed.getPictures().size() > 0) {
+            picture = feed.getPictures().get(0).getPath();
+        }
+        return FeedSimpleDto.builder()
+                .feedId(feed.getFeedId())
+                .picture(picture).build();
+    }
+
+    List<FeedSimpleDto> feedsToFeedSimpleDtos(List<Feed> feeds);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserGetResponseDto.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.user.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -9,23 +10,26 @@ import lombok.Setter;
 @Setter
 @NoArgsConstructor
 public class UserGetResponseDto {
+    @ApiModelProperty(value = "유저 식별자(id)")
     private Long userId;
-    private String email;
+    @ApiModelProperty(value = "유저 이름")
     private String name;
+    @ApiModelProperty(value = "유저 프로필 이미지 경로")
     private String profileImage;
-    private String location;
+    @ApiModelProperty(value = "고양이 프로필 개수")
     private Integer catCount;
+    @ApiModelProperty(value = "작성한 게시글 개수")
     private Long contentCount;
+    @ApiModelProperty(value = "유저가 팔로우하고 있는 유저수")
     private Long followingCount;
+    @ApiModelProperty(value = "유저를 팔로우하고 있는 유저수")
     private Long followerCount;
 
     @Builder
-    public UserGetResponseDto(Long userId, String email, String name, String profileImage, String location, Integer catCount, Long contentCount, Long followingCount, Long followerCount) {
+    public UserGetResponseDto(Long userId, String name, String profileImage, Integer catCount, Long contentCount, Long followingCount, Long followerCount) {
         this.userId = userId;
-        this.email = email;
         this.name = name;
         this.profileImage = profileImage;
-        this.location = location;
         this.catCount = catCount;
         this.contentCount = contentCount;
         this.followingCount = followingCount;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/entity/User.java
@@ -62,6 +62,15 @@ public class User extends DateTable {
     private String role;
 
     @Setter
+    @Column(name = "PROVIDER", length = 20)
+    private String provider;
+
+    @Setter
+    @OneToOne(cascade = CascadeType.REMOVE)
+    @JoinColumn(name = "REPRESENT_CAT_ID")
+    private Cat representCat;
+
+    @Setter
     @Column(name = "EXPIRY_DATE")
     private LocalDateTime expiryDate;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
@@ -45,17 +45,18 @@ public interface UserMapper {
         if (user == null) {
             return null;
         } else {
-            return UserGetResponseDto.builder()
+            UserGetResponseDto userGetResponseDto = UserGetResponseDto.builder()
                     .userId(user.getUserId())
-                    .email(user.getEmail())
                     .name(user.getName())
                     .profileImage(user.getProfileImage())
-                    .location(user.getLocation())
                     .catCount(user.getCats().size())
-                    .contentCount(user.getContentCount()) // TODO : edit after adding feed & board mapping
+                    .contentCount(user.getContentCount())
                     .followerCount(user.getFollowerCount())
                     .followingCount(user.getFollowingCount())
                     .build();
+
+
+            return userGetResponseDto;
         }
     }
 


### PR DESCRIPTION
## 주요 변경 사항
- user 엔티티에 representCat 추가 및 Cat에 1:1 단방향 매핑
- user 엔티티에 provider 추가
- CatSimpleDto 생성 및 매퍼에 매핑 로직 구현
- FeedSimpleDto 생성 및 매퍼에 매핑 로직 구현

## 코드 변경 이유
- DB에 칼럼 추가로 코드에 반영했습니다.
- provider는 oauth 회원 식별용입니다.
- 유저 프로필 페이지에 필요한 dto 생성했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- User 엔티티에 추가된 부분

## 연결된 이슈

## 자료 (스크린샷 등)
