### PR TITLE
[FE] 댓글 리팩토링

### DIFF
--- a/client/src/@types/feed.ts
+++ b/client/src/@types/feed.ts
@@ -40,12 +40,12 @@ export interface FeedDetail {
 
 export interface Comment {
   body: string
-  catId: number
+  catId?: number
   feedCommentId: number
   likeCount: number
   name: string
   profileImage: string
-  userId: number
+  userId?: number
 }
 
 export interface Picture {

--- a/client/src/components/template/Comments/Comments.tsx
+++ b/client/src/components/template/Comments/Comments.tsx
@@ -8,7 +8,7 @@ const Comments: FC<FeedDetail> = ({ comments }) => {
     <S.CommentsLayout>
       <S.CommentTitleBox>
         <S.CommentTitle>댓글</S.CommentTitle>
-        <S.CommentCount>3개</S.CommentCount>
+        <S.CommentCount>{comments.length}개</S.CommentCount>
       </S.CommentTitleBox>
       <S.CommentBox>
         {comments.map(item => (

--- a/client/src/components/template/Comments/Comments.tsx
+++ b/client/src/components/template/Comments/Comments.tsx
@@ -1,0 +1,28 @@
+import Comment from '@Atoms/Comment'
+import { FeedDetail } from '@Types/feed'
+import { FC } from 'react'
+import * as S from './Comments.style'
+
+const Comments: FC<FeedDetail> = ({ comments }) => {
+  return (
+    <S.CommentsLayout>
+      <S.CommentTitleBox>
+        <S.CommentTitle>댓글</S.CommentTitle>
+        <S.CommentCount>3개</S.CommentCount>
+      </S.CommentTitleBox>
+      <S.CommentBox>
+        {comments.map(item => (
+          <Comment
+            imageUrl={item.profileImage}
+            userName={item.name}
+            key={item.feedCommentId}
+          >
+            {item.body}
+          </Comment>
+        ))}
+      </S.CommentBox>
+    </S.CommentsLayout>
+  )
+}
+
+export default Comments

--- a/client/src/components/template/FeedDetail/FeedDetail.tsx
+++ b/client/src/components/template/FeedDetail/FeedDetail.tsx
@@ -1,23 +1,11 @@
 import Avatar from '@Atoms/Avatar'
 import Button from '@Atoms/Button'
 import Image from '@Atoms/Image'
-import { useEffect } from 'react'
-import { useParams } from 'react-router-dom'
+import { FeedDetail } from '@Types/feed'
+import { FC } from 'react'
 import * as S from './FeedDetail.style'
-import { useAppDispatch, useAppSelector } from '@/redux/store'
-import { getFeedDetailAsync } from '@/redux/actions/FeedDetailAction'
 
-const FeedDetail = () => {
-  const { id } = useParams()
-  const dispatch = useAppDispatch()
-  const { body, name, profileImage, pictures } = useAppSelector(
-    state => state.feedDetail.feedDetail,
-  )
-
-  useEffect(() => {
-    dispatch(getFeedDetailAsync(id as string))
-  }, [dispatch])
-
+const FeedDetail: FC<FeedDetail> = ({ body, name, profileImage, pictures }) => {
   return (
     <S.FeedDetailLayout>
       <S.UserInfoBox>

--- a/client/src/pages/Feed/FeedDetail/FeedDetail.tsx
+++ b/client/src/pages/Feed/FeedDetail/FeedDetail.tsx
@@ -1,12 +1,26 @@
-import FeedDetailview from '@Template/FeedDetail'
 import styled from 'styled-components'
+import FeedDetailView from '@Template/FeedDetail'
+import CommentsView from '@Template/Comments'
+import { FC, useEffect } from 'react'
+import { useParams } from 'react-router-dom'
+import { useAppDispatch, useAppSelector } from '@/redux/store'
+import { getFeedDetailAsync } from '@/redux/actions/FeedDetailAction'
 
 const FeedDetailLayout = styled.div``
 
-const FeedDetail = () => {
+const FeedDetail: FC = () => {
+  const { id } = useParams()
+  const dispatch = useAppDispatch()
+  const data = useAppSelector(state => state.feedDetail.feedDetail)
+
+  useEffect(() => {
+    dispatch(getFeedDetailAsync(id as string))
+  }, [dispatch])
+
   return (
     <FeedDetailLayout>
-      <FeedDetailview />
+      <FeedDetailView {...data} />
+      <CommentsView {...data} />
     </FeedDetailLayout>
   )
 }


### PR DESCRIPTION
## 주요 변경 사항
### Comments(댓글) 리팩토링
- 냥이생활의 댓글 응답 데이터가``catId`` 또는 ``userId`` 둘 중 하나만 전달받기 때문에 옵셔널 타입으로 지정해주었습니다.
- ``feedDetail`` state를 ``CommentsView``에서도 사용하기 위해 관련 로직을 상위 컴포넌트인 ``FeedDetail`` 페이지로 옮겼습니다.
- 페이지에서 state를 받아와 각각의 컴포넌트에 props로 전달합니다.

### 댓글 렌더링
- 응답 데이터에 따라 댓글을 렌더링하도록 구현했습니다.

## 코드 변경 이유
## 코드 리뷰 시 중점적으로 봐야할 부분
### 재사용성에 대한 고민
- ``Comments``(댓글) 템플릿이 냥이생활과 집사생활에 동일하게 적용되기 때문에 템플릿을 재사용하면 좋겠다고 생각했습니다.
- 다만 냥이생활과 집사생활의 댓글 응답 데이터의 필드명이 조금씩 달라 (ex. ``feedCommentId``와 ``boardCommentId``), 현재는 냥이생활 응답 데이터를 기준으로 렌더링하도록 구현되어있습니다. 이후 집사생활에서 댓글 데이터를 처리할 때 이 부분을 어떻게 활용할 수 있을지 의견 주시면 감사하겠습니다.
## 연결된 이슈
## 자료 (스크린샷 등)