### PR TITLE
feat: s3 파일 삭제 기능 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.common.picture.controller;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.service.S3UploadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,11 +10,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.io.IOException;
 
 //@Tag(name = "Upload", description = "파일 업로드 API")
@@ -29,5 +30,16 @@ public class FileUploadController {
     @PostMapping("/upload")
     public ResponseEntity uploadFile(@RequestParam("images") MultipartFile multipartFile) throws IOException {
         return new ResponseEntity<>(s3UploadService.upload(multipartFile), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "사용하지 않는 이미지 삭제", description = "S3에 업로드한 이미지 삭제",
+        responses = {
+            @ApiResponse(responseCode = "204", description = "이미지 삭제 성공")
+        }
+    )
+    @DeleteMapping("/images/delete")
+    public ResponseEntity deleteFile(@RequestBody PictureDto pictureDto) {
+        s3UploadService.delete(pictureDto.getPicture());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
@@ -4,10 +4,12 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.web.util.UrlUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -39,5 +41,10 @@ public class S3UploadService {
         amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
 
         return amazonS3.getUrl(bucket, s3FileName).toString();
+    }
+
+    public void delete(String path) {
+        String key = URLDecoder.decode(path.replace("https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/", ""));
+        amazonS3.deleteObject(bucket, key);
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- FileUploadController에 이미지 삭제 요청 받을 deleteFile 메서드 구현
- S3UploadService에 이미지 삭제 로직 구현

## 코드 변경 이유
- 사용자가 파일에서 이미지 선택하여 업로드시 바로 S3 이미지 서버에 저장되지만 사용자가 이미지를 게시하지 않을 경우 사용하지 않는 이미지가 그대로 S3에 남아 문제 발생할 수 있어 사용하지 않은 이미지는 삭제하는 API 구현했습니다.
- /images/delete 엔드포인트로 이미지 경로 body에 담아서 보내면 이미지가 s3에서 삭제됩니다.
- 삭제 시 SDK 지원 메서드인 deleteObject에 S3의 버킷과 키를 입력하여 삭제합니다.
- 한글이 포함된 URL은 인코딩되어 있어 삭제되지 않는 오류 발생하여 url을 디코딩하여 String으로 변환후 삭제 요청합니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 로직이 올바른지
- 엔드포인트가 적절한지

## 연결된 이슈
close #280 

## 자료 (스크린샷 등)
