### PR TITLE
feat: 게시글 작성 수 count 로직 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/controller/BoardController.java
@@ -96,6 +96,10 @@ public class BoardController {
         board.setUser(findUser);
 
         Board createdBoard = boardService.createBoard(board, requestBody.getTags(), requestBody.getPictures());
+
+        // 유저 contentCount + 1하여 저장
+        userService.addContentCount(findUser);
+
         return new ResponseEntity<>(
                 boardMapper.boardToBoardPostResponseDto(createdBoard),
                 HttpStatus.CREATED);
@@ -134,6 +138,10 @@ public class BoardController {
                                       @Positive @PathVariable("board-id") Long boardId) {
         User findUser = userService.findVerifiedEmail(user.getUsername());
         boardService.deleteBoard(findUser, boardId);
+
+        // 유저 contentCount - 1하여 저장
+        userService.removeContentCount(findUser);
+
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/controller/FileUploadController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.common.picture.controller;
 
+import com.twentyfour_seven.catvillage.common.picture.dto.PictureDto;
 import com.twentyfour_seven.catvillage.common.picture.service.S3UploadService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
@@ -9,11 +10,11 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
 
+import javax.validation.Valid;
 import java.io.IOException;
 
 //@Tag(name = "Upload", description = "파일 업로드 API")
@@ -29,5 +30,16 @@ public class FileUploadController {
     @PostMapping("/upload")
     public ResponseEntity uploadFile(@RequestParam("images") MultipartFile multipartFile) throws IOException {
         return new ResponseEntity<>(s3UploadService.upload(multipartFile), HttpStatus.CREATED);
+    }
+
+    @Operation(summary = "사용하지 않는 이미지 삭제", description = "S3에 업로드한 이미지 삭제",
+        responses = {
+            @ApiResponse(responseCode = "204", description = "이미지 삭제 성공")
+        }
+    )
+    @DeleteMapping("/images/delete")
+    public ResponseEntity deleteFile(@RequestBody PictureDto pictureDto) {
+        s3UploadService.delete(pictureDto.getPicture());
+        return new ResponseEntity<>(HttpStatus.NO_CONTENT);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/service/S3UploadService.java
@@ -4,10 +4,12 @@ import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.web.util.UrlUtils;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
+import java.net.URLDecoder;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -39,5 +41,10 @@ public class S3UploadService {
         amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
 
         return amazonS3.getUrl(bucket, s3FileName).toString();
+    }
+
+    public void delete(String path) {
+        String key = URLDecoder.decode(path.replace("https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/", ""));
+        amazonS3.deleteObject(bucket, key);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -9,13 +9,12 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.repository.FeedRepository;
-import com.twentyfour_seven.catvillage.user.service.FollowService;
 import com.twentyfour_seven.catvillage.user.entity.User;
+import com.twentyfour_seven.catvillage.user.service.FollowService;
 import com.twentyfour_seven.catvillage.user.service.UserService;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
-import org.springframework.security.core.parameters.P;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -49,9 +48,10 @@ public class FeedService {
     public Feed createFeed(Feed feed, long catId, String email) {
         // 작성한 고양이 프로필이 유효한지 확인
         Cat findCat = catService.findVerifiedCat(catId);
+        User user = findCat.getUser();
 
         // 로그인한 유저의 고양이가 아닐경우 에러
-        if (!findCat.getUser().getEmail().equals(email)) {
+        if (!user.getEmail().equals(email)) {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
         }
 
@@ -70,6 +70,10 @@ public class FeedService {
 
         // feed 저장 후 반환
         Feed saveFeed = feedRepository.save(feed);
+
+        // 유저에 contentCount +1 하여 저장
+        userService.addContentCount(user);
+
         return saveFeed;
     }
 
@@ -151,6 +155,9 @@ public class FeedService {
             throw new BusinessLogicException(ExceptionCode.INVALID_USER);
         }
         feedRepository.delete(findFeed);
+
+        // 유저에 contentCount - 1 하여 저장
+        userService.removeContentCount(findUser);
     }
 
     public void addLike(long feedId, String email) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -96,4 +96,14 @@ public class UserService {
             throw new BusinessLogicException(ExceptionCode.MEMBER_NAME_EXISTS);
         }
     }
+
+    public void addContentCount(User user) {
+        user.setContentCount(user.getContentCount() + 1);
+        userRepository.save(user);
+    }
+
+    public void removeContentCount(User user) {
+        user.setContentCount(user.getContentCount() - 1);
+        userRepository.save(user);
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
- userService에 addContentCount, deleteContentCount 로직 구현
- feedService에 create, delete 로직에 contentCount 업데이트 로직 추가
- boardController에 create,delete 로직에 contentCount 업데이트 로직 추가

## 코드 변경 이유
- 유저 테이블과 유저 프로필 페이지에 게시글 수가 있지만 실제로 count 하는 로직이 없어 contentCount가 모두 0으로 저장되어 있어 냥이생활또는 집사생활에 글 작성, 삭제 시 contentCount가 업데이트 되도록 구현했습니다.
- feed는 feedService에 UserService가 주입되어 있어 서비스단에서 호출하도록 구현했습니다.
- board는 boardController에 UserService가 주입되어 있어 컨트롤러단에서 호출하도록 구현했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 로직이 적절한지
- 빠진 부분은 없는지

## 연결된 이슈
close #272 

## 자료 (스크린샷 등)
