### PR TITLE
fix: 냥이생활 피드 작성 페이지 수정

### DIFF
--- a/client/src/components/modules/FormTextInput/FormTextInput.tsx
+++ b/client/src/components/modules/FormTextInput/FormTextInput.tsx
@@ -18,6 +18,7 @@ export interface Props {
   rows?: number
   /** onFocusOut handler */
   onFocusOut?: (e: React.FocusEvent<HTMLInputElement>) => void
+  onChange?: (e: React.ChangeEvent<HTMLTextAreaElement>) => void
 }
 
 const ContentInput: FC<Props> = forwardRef(({ inputName, ...props }, ref) => {

--- a/client/src/components/template/FeedForm/FeedForm.tsx
+++ b/client/src/components/template/FeedForm/FeedForm.tsx
@@ -1,25 +1,62 @@
-import ImageInput from '@Modules/ImageInput'
-
+import { axiosInstance } from '@Utils/instance'
+import { Back } from '@Assets/icons'
+import { useNavigate } from 'react-router-dom'
+import { useState } from 'react'
 import * as S from './FeedForm.style'
 
 const FeedForm = () => {
-  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) =>
+  const [body, setBody] = useState<string>('')
+  const navigate = useNavigate()
+  const getImgUrl = async (formData: FormData): Promise<string> => {
+    const axiosResponse = await axiosInstance.post('/upload', formData, {
+      headers: {
+        'content-type': 'multipart/form-data',
+        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+      },
+    })
+    /*          // HttpStatus가 200번호 구역이 아니거나
+      // 서버에서 응답 코드로 0(성공)을 주지 않았을 경우
+      if (
+        axiosResponse.status < 200 ||
+        axiosResponse.status >= 300 ||
+        axiosResponse.data.resultCode !== 0
+      ) {
+        // Error를 발생시켜 Catch문을 타게 만들어주는데, 서버에 응답받은 메시지를 넣어준다!
+        // 서버에서 응답 메시지를 받지 못했을경우 기본 메시지 설정또한 함께 해준다
+        throw Error(axiosResponse.data.message || '문제가 발생했어요!')
+      } */
+
+    return axiosResponse.data
+  }
+  const handleSubmit = (event: React.FormEvent<HTMLFormElement>) => {
     event.preventDefault()
+    console.log(body)
+  }
+
   return (
     <S.FeedFormLayout>
+      <S.Header className="header">
+        <button type="button" onClick={() => navigate(-1)}>
+          <Back />
+        </button>
+        <span>글쓰기</span>
+      </S.Header>
       <S.ImageInputBox>
-        {/* <ImageInput inputName="image-input" /> */}
+        <S.FeedImageInput inputName="image-input" onPost={getImgUrl} />
       </S.ImageInputBox>
       {/* <S.TitleInput inputName="title-input" placeholder="글제목" /> */}
       <S.BodyInput
         inputName="body-input"
         placeholder="본문에 #을 이용해 태그를 입력해보세요!"
+        defaultValue={body}
+        onChange={e => setBody(e.target.value)}
       />
       <S.SubmitButton
         backgroundColor="primary"
         color="white"
         fontSize="md"
         fontWeight="bold"
+        type="submit"
       >
         게시하기
       </S.SubmitButton>

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -8,11 +8,11 @@ const NewFeed = () => {
   const { isLogin } = useAppSelector(state => state.user)
 
   useEffect(() => {
-    if (!isLogin) {
+    if (isLogin) {
       alert('로그인이 필요한 서비스입니다🐱')
       navigate('/login')
     }
-  }, [])
+  }, [isLogin])
 
   return <FeedForm />
 }

--- a/client/src/pages/Page404/index.tsx
+++ b/client/src/pages/Page404/index.tsx
@@ -1,5 +1,33 @@
+import styled from 'styled-components'
+import { FEED_PATH } from '@Routes/feed.routes'
+import { Link } from 'react-router-dom'
+
+const NotFoundPageLayout = styled.div`
+  width: 100%;
+  height: 100%;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 20px;
+  background-color: ${({ theme }) => theme.color.white};
+  color: ${({ theme }) => theme.color.primary};
+`
+
+const NotFoundContent = styled.div`
+  font-size: ${({ theme }) => theme.fontSize.xl};
+  font-weight: ${({ theme }) => theme.fontWeight.bold};
+`
+
 const Page404 = () => {
-  return <div>404 페이지입니다.</div>
+  return (
+    <NotFoundPageLayout>
+      <NotFoundContent>서비스 준비중입니다!🐱</NotFoundContent>
+      <Link to={`/${FEED_PATH}`}>
+        <div>👉 뒤로 가기</div>
+      </Link>
+    </NotFoundPageLayout>
+  )
 }
 
 export default Page404


### PR DESCRIPTION
## 주요 변경 사항
- 냥이생활 피드 작성 페이지의 이미지 업로드 컴포넌를 불러와 이미지 미리보기 기능이 동작하도록 했습니다.
- 냥이생활 피드 작성 페이지에서 로그인 체크 유무 로직을 수정했습니다.

## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈

## 자료 (스크린샷 등)
<img width="1440" alt="image" src="https://user-images.githubusercontent.com/88873956/194742994-1248e58b-ad34-414d-bba1-09be1830641e.png">

