### PR TITLE
feat: 특정 유저가 작성한 피드 불러오는 API 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -71,7 +71,8 @@ public class SwaggerConfig {
                         typeResolver.resolve(FollowerResponseDto.class),
                         typeResolver.resolve(FollowingResponseDto.class),
                         typeResolver.resolve(CatUserResponseDto.class),
-                        typeResolver.resolve(CatSimpleDto.class)
+                        typeResolver.resolve(CatSimpleDto.class),
+                        typeResolver.resolve(FeedSimpleDto.class)
                 )
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -11,7 +11,6 @@ import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
 import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
-import com.twentyfour_seven.catvillage.user.service.UserService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;
@@ -258,7 +257,7 @@ public class FeedController {
             })
     @PostMapping("/comments/{comments-id}/like")
     public ResponseEntity postLikeInComment(@PathVariable("comments-id") @Positive long commentsId,
-                                         @AuthenticationPrincipal User user) {
+                                            @AuthenticationPrincipal User user) {
         feedCommentService.addLike(commentsId, user.getUsername());
         return new ResponseEntity<>(HttpStatus.CREATED);
     }
@@ -271,8 +270,21 @@ public class FeedController {
             })
     @DeleteMapping("/comments/{comments-id}/like")
     public ResponseEntity deleteLikeInComment(@PathVariable("comments-id") @Positive long commentId,
-                                           @AuthenticationPrincipal User user) {
+                                              @AuthenticationPrincipal User user) {
         feedCommentService.deleteLike(commentId, user.getUsername());
         return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+    }
+
+    @Operation(summary = "특정 유저가 작성한 피드 정보 조회", description = "유저 프로필 페이지에 들어갈 정보",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "피드 조회 성공",
+                            content = @Content(schema = @Schema(implementation = FeedSimpleDto.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 유저")
+            }
+    )
+    @GetMapping("/users/{users-id}")
+    public ResponseEntity getFeedFromUser(@PathVariable("users-id") @Positive long userId) {
+        List<Feed> feeds = feedService.findFeedByUser(userId);
+        return new ResponseEntity<>(feedMapper.feedsToFeedSimpleDtos(feeds), HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/repository/FeedRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/repository/FeedRepository.java
@@ -1,7 +1,11 @@
 package com.twentyfour_seven.catvillage.feed.repository;
 
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface FeedRepository extends JpaRepository<Feed, Long> {
+    List<Feed> findByCat(Cat cat);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -190,4 +190,12 @@ public class FeedService {
         User findUser = userService.findVerifiedEmail(email);
         return likeService.findExistLike(feed, findUser);
     }
+
+    public List<Feed> findFeedByUser(long userId) {
+        User findUser = userService.findUser(userId);
+
+        List<Feed> findFeeds = new ArrayList<>();
+        findUser.getCats().forEach(cat -> findFeeds.addAll(feedRepository.findByCat(cat)));
+        return findFeeds;
+    }
 }


### PR DESCRIPTION
## 주요 변경 사항
- FeedController에 API 추가
- FeedService에 특정유저의 모든 고양이 프로필로 작성한 피드 가져오는 로직 구현
- FeedRepository에 findByCat 추가
- SwaggerConfig에 FeedSimpleDto 추가

## 코드 변경 이유
- 유저 프로필 페이지에 들어갈 특정 유저가 작성한 피드정보 불러오는 API 구현했습니다.
- 엔드포인트는 /냥이생활/users/{users-id} 입니다.
- 특정 유저의 모든 고양이를 조회하여고 고양이로 작성한 모든 피드를 조회합니다.
- 피드 정보에 대표사진 1장과 클릭했을 때 페이지 넘어가는데 필요한 id 값만 반환합니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- FeedService
- FeedController
- FeedRepository

## 연결된 이슈
close #274 

## 자료 (스크린샷 등)
