### PR TITLE
fix: 집사생활 전체 게시글 조회 버그 수정

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/mapper/BoardMapper.java
@@ -67,7 +67,7 @@ public interface BoardMapper {
                     .tags(board.getTagToBoards().stream()
                             .map(e -> new BoardTagDto(e.getBoardTag()))
                             .collect(Collectors.toList()))
-                    .picture(board.getPictures() == null ? "" : board.getPictures().get(0).getPath())
+                    .picture(board.getPictures() == null  || board.getPictures().size() == 0 ? "" : board.getPictures().get(0).getPath())
                     .viewCount(board.getViewCount())
                     .likeCount(board.getLikeCount())
                     .commentCount(board.getCommentCount())


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활 전체 게시글 조회 시 index out of bound 에러 수정

## 코드 변경 이유
- index out of bound 발생하며 조회 안되는 버그 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- picture의 size가 '0'인 경우는 확인을 안하는 바람에 발생하던 문제 수정

## 연결된 이슈

## 자료 (스크린샷 등)
