### PR TITLE
fix: picture 및 tag의 유효성 검증 추가, tag NPE 버그 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPatchDto.java
@@ -6,20 +6,28 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Validated
 public class BoardPatchDto {
     private Long boardId;
     @Length(max = 64)
     private String title;
     @Length(max = 1000)
     private String body;
+
+    @NotEmpty
     private List<BoardTagDto> tags = new ArrayList<>();
+
+    @Valid
     private List<PictureDto> pictures = new ArrayList<>();
 
     @Builder

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/dto/BoardPostDto.java
@@ -6,19 +6,27 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import java.util.ArrayList;
 import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
+@Validated
 public class BoardPostDto {
     @Length(max = 64)
     private String title;
     @Length(max = 1000)
     private String body;
+
+    @NotEmpty
     private List<BoardTagDto> tags = new ArrayList<>();
+
+    @Valid
     private List<PictureDto> pictures = new ArrayList<>();
 
     @Builder

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
@@ -7,13 +7,15 @@ import lombok.Setter;
 import org.hibernate.validator.constraints.Length;
 import org.springframework.validation.annotation.Validated;
 
-import javax.validation.constraints.Max;
+import javax.validation.constraints.Pattern;
+
 
 @Getter
 @Setter
 @NoArgsConstructor
 @Validated
 public class PictureDto {
+    @Pattern(regexp = "^((https?|http?|)://)$")
     @Length(max = 500)
     private String picture;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedPostDto.java
@@ -6,6 +6,8 @@ import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.Positive;
 import java.util.List;
 
@@ -16,6 +18,8 @@ import java.util.List;
 public class FeedPostDto {
     @Positive
     private long catId;
+    @NotEmpty
+    @Valid
     private List<PictureDto> pictures;
     private String body;
     private List<FeedTagDto> tags;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedTagService.java
@@ -23,7 +23,7 @@ public class FeedTagService {
     }
 
     public List<FeedTag> createTags(Feed feed, List<FeedTag> feedTags) {
-        if (feedTags.isEmpty()) {
+        if (feedTags == null || feedTags.isEmpty()) {
             return null;
         }
         List<FeedTag> saveFeedTags = new ArrayList<>();

--- a/server/catvillage/src/main/resources-prod/application.yml
+++ b/server/catvillage/src/main/resources-prod/application.yml
@@ -10,7 +10,7 @@ spring:
   jpa:
     database-platform: org.hibernate.dialect.MariaDB106Dialect
     open-in-view: false
-    show-sql: true
+    show-sql: false
     hibernate:
       ddl-auto: none
       naming:

--- a/server/catvillage/src/main/resources/application-common.yml
+++ b/server/catvillage/src/main/resources/application-common.yml
@@ -5,7 +5,7 @@ spring:
         jdbc:
           time_zone: UTC  # DB Timezone configure
         format_sql: true  # SQL pretty print
-    show-sql: true
+    show-sql: false
   security:
     oauth2:
       client:


### PR DESCRIPTION
## 주요 변경 사항
- Feed 작성 또는 수정 시 picture 리스트가 null 또는 empty(길이0)인지 확인하도록 유효성 검증 추가
- pictureDto에 이미지 경로가 http 또는 https로 시작하는지 확인하는 유효성 검증 추가
- feedTagService에 feedTag가 isEmpty인지 체크하는 부분 앞에 null 인지 먼저 체크하도록 수정
- BoardPostDto 및 BoardPatchDto에 tags null 또는 empty인지 확인, pictures @Valid 추가
- 모든 yml 설정 파일에서 show-sql을 false로 수정

## 코드 변경 이유
- 설계 상 냥이생활 피드는 사진이 1장 이상이어야 하기 때문에 비어있으면 안되서 유효성 검증 로직을 추가했습니다.
- 이미지에 url 경로가 아닌 다른 경로가 들어올 수 있어 http or https 로 시작하는 문자열인지 확인하도록 검증 코드 추가했습니다.
- feed 작성 시 tag는 nullable인데 feedService 로직에서 null 일 경우 feedTag.isEmpty 메서드 호출 부분에서 NPE가 발생하여 null인지 먼저 확인하도록 수졍하였고 에러 나지 않는지 포스트맨으로 확인 완료했습니다.
- DTO 내의 DTO 리스트의 유효성 검증이 정상적으로 이루어지지 않아 호출하는 부분에 @Valid 애너테이션 추가하여 해결했습니다.
- sql log가 너무 많아 가독성이 떨어지고 log 파일 용량 문제가 발생하여 sql문은 log에 남기지 않도록 설정을 변경했습니다.(이 부분에 대한 피드백 부탁드립니다.)

## 코드 리뷰 시 중점적으로 봐야할 부분
- 유효성 검증 애너테이션이 적절한지
- 정규표현식이 적절한지
- yml 파일의 변경된 부분

## 연결된 이슈
- close #295 

## 자료 (스크린샷 등)
