### PR TITLE
feat: 대표 고양이 설정 API 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/controller/CatController.java
@@ -133,4 +133,17 @@ public class CatController {
 
         return new ResponseEntity<>(catMapper.catsToCatUserResponseDto(findCats), HttpStatus.OK);
     }
+
+    @Operation(summary = "대표고양이 등록, 변경하기",
+            description = "대표고양이가 없을 경우 저장, 변경 시 업데이트 모두 해당 API로 요청 보내시면 됩니다.(이미 있는 경우 데이터가 덮어 씌어집니다.)",
+            responses = {
+                    @ApiResponse(responseCode = "201", description = "대표고양이 등록 성공"),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 유저 or 존재하지 않는 고양이")
+            })
+    @PostMapping("/{cats-id}/대표")
+    public ResponseEntity postRepresentCat(@PathVariable("cats-id") @Positive long catId,
+                                           @AuthenticationPrincipal User user) {
+        catService.updateRepresentCat(catId, user.getUsername());
+        return new ResponseEntity<>(HttpStatus.CREATED);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -37,7 +37,14 @@ public class CatService {
         User findUser = userService.findVerifiedEmail(email);
         cat.setUser(findUser);
 
-        return catRepository.save(cat);
+        Cat saveCat = catRepository.save(cat);
+
+        // user에 등록된 대표고양이가 없을 경우 대표 고양이로 등록
+        if (findUser.getRepresentCat() == null) {
+            userService.updateRepresentCat(findUser, saveCat);
+        }
+
+        return saveCat;
     }
 
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/cat/service/CatService.java
@@ -107,4 +107,10 @@ public class CatService {
 
         return resultCats;
     }
+
+    public void updateRepresentCat(long catId, String username) {
+        User findUser = userService.findVerifiedEmail(username);
+        Cat findCat = findVerifiedCat(catId);
+        userService.updateRepresentCat(findUser, findCat);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/service/UserService.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.user.service;
 
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.user.entity.User;
@@ -104,6 +105,11 @@ public class UserService {
 
     public void removeContentCount(User user) {
         user.setContentCount(user.getContentCount() - 1);
+        userRepository.save(user);
+    }
+
+    public void updateRepresentCat(User user, Cat cat) {
+        user.setRepresentCat(cat);
         userRepository.save(user);
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- post-cat 요청 로직에 user에 representCat 이 지정되어 있지 않을 경우 자동으로 요청으로 보낸 고양이를 user의 representCat으로 설정하도록 로직 구현
- UserService에 updateRepresentCat 메서드 구현
- 대표고양이 지정 API 구현

## 코드 변경 이유
- 고양이 최초 등록 시 자동으로 대표고양이로 설정하도록 설계하여서 설계에 맞춰 post-cat 로직에 코드 추가하였습니다.
- representCat은 User에 있는 칼럼이기 때문에 UserService에 대표고양이를 업데이트하는 메서드를 구현했습니다.
- 대표고양이를 고양이 프로필에서 버튼 클릭으로 지정할 수 있도록 설정하였기 때문에 API 구현했습니다. 엔드포인트는` /cats/{cats-id}/대표 `입니다.
- 대표고양이 지정은 delete 요청은 적절하지 않다고 생각하여 post 요청만 구현했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 추가된 코드가 매우 간단하기 때문에 빠뜨린 부분이나 잘못된 부분이 없는지만 체크 부탁드립니다 :)

## 연결된 이슈
- close #301 
- close #277 

## 자료 (스크린샷 등)
