### PR TITLE
[FE] 냥이생활 좋아요 추가/취소 기능 구현

### DIFF
--- a/client/src/pages/Feed/Feeds/Feeds.tsx
+++ b/client/src/pages/Feed/Feeds/Feeds.tsx
@@ -8,8 +8,11 @@ import { FEED_PATH } from '@Routes/feed.routes'
 import * as S from './Feeds.style'
 import { SvgButtonCssProp, AvatarCssProp } from './Feeds.style'
 import { useAppDispatch, useAppSelector } from '@/redux/store'
-import { getFeedsAsync, addLikeAsync } from '@/redux/actions/FeedsAction'
-import { toggleLike } from '@/redux/reducers/FeedsSlice'
+import {
+  getFeedsAsync,
+  addLikeAsync,
+  cancelLikeAsync,
+} from '@/redux/actions/FeedsAction'
 
 const Feeds = () => {
   const navigate = useNavigate()
@@ -21,7 +24,7 @@ const Feeds = () => {
     dispatch(getFeedsAsync())
   }, [])
 
-  const handleLikeClick = (feedId: number) => {
+  const handleLikeClick = (feedId: number, isLike: boolean) => {
     if (localStorage.getItem('ACCESS_TOKEN') === null) {
       alert('로그인이 필요한 서비스입니다🐱')
       navigate('/login')
@@ -30,7 +33,11 @@ const Feeds = () => {
     //   alert('로그인이 필요한 서비스입니다🐱')
     //   navigate('/login')
 
-    dispatch(addLikeAsync(feedId))
+    if (!isLike) {
+      dispatch(addLikeAsync(feedId))
+    } else {
+      dispatch(cancelLikeAsync(feedId))
+    }
   }
 
   return (
@@ -57,7 +64,7 @@ const Feeds = () => {
                 <SvgButton
                   icon={item.isLike ? 'EmptyHeartIcon' : 'HeartIcon'}
                   cssProp={SvgButtonCssProp}
-                  onClick={() => handleLikeClick(item.feedId)}
+                  onClick={() => handleLikeClick(item.feedId, item.isLike)}
                 />
               </S.FeedItem>
             )

--- a/client/src/pages/Feed/Feeds/Feeds.tsx
+++ b/client/src/pages/Feed/Feeds/Feeds.tsx
@@ -8,7 +8,7 @@ import { FEED_PATH } from '@Routes/feed.routes'
 import * as S from './Feeds.style'
 import { SvgButtonCssProp, AvatarCssProp } from './Feeds.style'
 import { useAppDispatch, useAppSelector } from '@/redux/store'
-import { getFeedsAsync } from '@/redux/actions/FeedsAction'
+import { getFeedsAsync, addLikeAsync } from '@/redux/actions/FeedsAction'
 import { toggleLike } from '@/redux/reducers/FeedsSlice'
 
 const Feeds = () => {
@@ -19,15 +19,18 @@ const Feeds = () => {
 
   useEffect(() => {
     dispatch(getFeedsAsync())
-  }, [dispatch])
+  }, [])
 
   const handleLikeClick = (feedId: number) => {
     if (localStorage.getItem('ACCESS_TOKEN') === null) {
       alert('로그인이 필요한 서비스입니다🐱')
       navigate('/login')
-    } else {
-      dispatch(toggleLike(feedId))
     }
+    // if (!isLogin) {
+    //   alert('로그인이 필요한 서비스입니다🐱')
+    //   navigate('/login')
+
+    dispatch(addLikeAsync(feedId))
   }
 
   return (

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -8,10 +8,14 @@ const NewFeed = () => {
   const { isLogin } = useAppSelector(state => state.user)
 
   useEffect(() => {
-    if (isLogin) {
+    if (localStorage.getItem('ACCESS_TOKEN') === null) {
       alert('로그인이 필요한 서비스입니다🐱')
       navigate('/login')
     }
+    // if (!isLogin) {
+    //   alert('로그인이 필요한 서비스입니다🐱')
+    //   navigate('/login')
+    // }
   }, [isLogin])
 
   return <FeedForm />

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -3,7 +3,7 @@ import SocialLoginButton from '@Modules/SocialLoginButton'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import { FormValue } from '@pages/Signup/Signup'
 import { ValidationSpan } from '@pages/Signup/Signup.style'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, Link } from 'react-router-dom'
 import { FEED_PATH } from '@Routes/feed.routes'
 import logo from '@Assets/logo.svg'
 import * as S from './Login.style'
@@ -103,7 +103,9 @@ const Login: FC = () => {
       </S.InputForm>
       <S.ButtonBox>
         <S.FindButton>아이디/비밀번호 찾기</S.FindButton>
-        <S.SignupButton>회원가입</S.SignupButton>
+        <Link to="/signup">
+          <S.SignupButton>회원가입</S.SignupButton>
+        </Link>
       </S.ButtonBox>
       <SocialLoginButton onClick={handleSocialLogin} />
     </S.LoginLayout>

--- a/client/src/pages/Signup/Signup.tsx
+++ b/client/src/pages/Signup/Signup.tsx
@@ -2,6 +2,7 @@ import { useState, FC, useRef } from 'react'
 import SocialLoginButton from '@Modules/SocialLoginButton'
 import { useForm, SubmitHandler } from 'react-hook-form'
 import logo from '@Assets/logo.svg'
+import { Link } from 'react-router-dom'
 import * as S from './Signup.style'
 import { useAppDispatch } from '@/redux/store'
 import { signupAsync } from '@/redux/actions/userAction'
@@ -119,7 +120,9 @@ const Signup: FC = () => {
       </S.InputForm>
       <S.Box>
         <span>이미 가입하셨나요?</span>
-        <S.LoginButton>로그인</S.LoginButton>
+        <Link to="/login">
+          <S.LoginButton>로그인</S.LoginButton>
+        </Link>
       </S.Box>
       <SocialLoginButton onClick={handleSocialLogin} />
     </S.SignupLayout>

--- a/client/src/redux/actions/FeedsAction.ts
+++ b/client/src/redux/actions/FeedsAction.ts
@@ -34,11 +34,36 @@ export const addLikeAsync = createAsyncThunk<
   CreateAsyncThunkTypes
 >('feeds/addLikeAsync', async (feedId, thunkAPI) => {
   try {
-    const { data } = await axiosInstance.post(`/${FEED_PATH}/${feedId}/like`, {
-      headers: {
-        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+    const { data } = await axiosInstance.post(
+      `/${FEED_PATH}/${feedId}/like`,
+      null,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+        },
       },
-    })
+    )
+    return feedId
+  } catch (error: any) {
+    return thunkAPI.rejectWithValue(error.message)
+  }
+})
+
+// 좋아요 취소하기
+export const cancelLikeAsync = createAsyncThunk<
+  any,
+  number,
+  CreateAsyncThunkTypes
+>('feeds/cancelLikeAsync', async (feedId, thunkAPI) => {
+  try {
+    const { data } = await axiosInstance.delete(
+      `/${FEED_PATH}/${feedId}/like`,
+      {
+        headers: {
+          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+        },
+      },
+    )
     return feedId
   } catch (error: any) {
     return thunkAPI.rejectWithValue(error.message)

--- a/client/src/redux/actions/FeedsAction.ts
+++ b/client/src/redux/actions/FeedsAction.ts
@@ -4,6 +4,7 @@ import { FEED_PATH } from '@Routes/feed.routes'
 import { Feeds } from '@Types/feed'
 import { CreateAsyncThunkTypes } from '../store'
 
+// 냥이생활 전체 피드 불러오기
 export const getFeedsAsync = createAsyncThunk<
   Feeds,
   undefined,
@@ -21,6 +22,24 @@ export const getFeedsAsync = createAsyncThunk<
       },
     )
     return data
+  } catch (error: any) {
+    return thunkAPI.rejectWithValue(error.message)
+  }
+})
+
+// 좋아요 추가하기
+export const addLikeAsync = createAsyncThunk<
+  any,
+  number,
+  CreateAsyncThunkTypes
+>('feeds/addLikeAsync', async (feedId, thunkAPI) => {
+  try {
+    const { data } = await axiosInstance.post(`/${FEED_PATH}/${feedId}/like`, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+      },
+    })
+    return feedId
   } catch (error: any) {
     return thunkAPI.rejectWithValue(error.message)
   }

--- a/client/src/redux/reducers/FeedsSlice.ts
+++ b/client/src/redux/reducers/FeedsSlice.ts
@@ -1,6 +1,6 @@
 import { createSlice, Reducer, PayloadAction } from '@reduxjs/toolkit'
 import { Feed, Feeds } from '@Types/feed'
-import { getFeedsAsync } from '../actions/FeedsAction'
+import { getFeedsAsync, addLikeAsync } from '../actions/FeedsAction'
 
 const initialState: Feeds = {
   feed: [],
@@ -38,6 +38,17 @@ const feedsSlice = createSlice({
       })
       .addCase(getFeedsAsync.rejected, () => {
         alert('피드를 불러오는 데 실패했습니다:(')
+      })
+      // 좋아요 추가하기
+      .addCase(addLikeAsync.pending, state => {
+        state.isLoading = true
+      })
+      .addCase(addLikeAsync.fulfilled, (state, { payload }) => {
+        const data = state.feed?.find(item => item.feedId === payload) as Feed
+        data.isLike = !data.isLike
+      })
+      .addCase(addLikeAsync.rejected, () => {
+        console.error()
       })
   },
 })

--- a/client/src/redux/reducers/FeedsSlice.ts
+++ b/client/src/redux/reducers/FeedsSlice.ts
@@ -1,6 +1,10 @@
 import { createSlice, Reducer, PayloadAction } from '@reduxjs/toolkit'
 import { Feed, Feeds } from '@Types/feed'
-import { getFeedsAsync, addLikeAsync } from '../actions/FeedsAction'
+import {
+  getFeedsAsync,
+  addLikeAsync,
+  cancelLikeAsync,
+} from '../actions/FeedsAction'
 
 const initialState: Feeds = {
   feed: [],
@@ -48,6 +52,17 @@ const feedsSlice = createSlice({
         data.isLike = !data.isLike
       })
       .addCase(addLikeAsync.rejected, () => {
+        console.error()
+      })
+      // 좋아요 취소하기
+      .addCase(cancelLikeAsync.pending, state => {
+        state.isLoading = true
+      })
+      .addCase(cancelLikeAsync.fulfilled, (state, { payload }) => {
+        const data = state.feed?.find(item => item.feedId === payload) as Feed
+        data.isLike = !data.isLike
+      })
+      .addCase(cancelLikeAsync.rejected, () => {
         console.error()
       })
   },


### PR DESCRIPTION
## 주요 변경 사항
### 1. 냥이생활 좋아요 추가 기능
- 냥이생활 좋아요 추가 기능을 구현했습니다.
- 구현하는 중에 에러를 발견해 @leejuhanKr 님이 이슈를 등록하고 해결해주셨습니다.
- 에러 해결 과정은 #303 이슈에서 자세히 확인할 수 있습니다.

### 2. 냥이생활 좋아요 취소 기능
- 냥이생활 좋아요 취소 기능을 구현했습니다.
- 좋아요 추가/취소 기능을 냥이생활 전체 피드에 적용했습니다.

### 3. 로그인/회원가입 페이지 버튼에 경로 추가
- 로그인/회원가입 페이지에 각각의 페이지로 이동하는 버튼이 있습니다.
(로그인 페이지 -> 회원가입 페이지로 이동하는 버튼 / 회원가입 페이지 -> 로그인 페이지로 이동하는 버튼)
- ``Link`` 컴포넌트를 사용해 해당 페이지로 이동하도록 했습니다.

## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈
#303
#208 

## 자료 (스크린샷 등)
