### PR TITLE
fix: 배포용에선 SQL 로그 제거

### DIFF
--- a/server/catvillage/src/main/resources-prod/application.yml
+++ b/server/catvillage/src/main/resources-prod/application.yml
@@ -26,15 +26,15 @@ spring:
             client-id: $KAKAO_API_KEY
             client-secret: $KAKAO_CLIENT_SECRET
             redirect-uri: https://catvillage.tk/login/oauth2/code/kakao
-logging:
-  level:
-    org:
-      hibernate:
-        SQL: DEBUG
-        type:
-          descriptor:
-            sql:
-              BasicBinder: TRACE
+#logging:
+#  level:
+#    org:
+#      hibernate:
+#        SQL: DEBUG
+#        type:
+#          descriptor:
+#            sql:
+#              BasicBinder: TRACE
 jwt:
   secret: $JWT_SECRET
 cloud:


### PR DESCRIPTION
## 주요 변경 사항
- 배포용에서는 SQL 로그가 출력되지 않도록 수정

## 코드 변경 이유
- SQL 로그가 너무 쌓이던 문제 수정을 위해 로그 설정 주석

## 코드 리뷰 시 중점적으로 봐야할 부분
- `show-sql` 설정이 아닌 주석 처리한 설정으로도 sql 로그를 설정할 수 있음을 확인해주시면 될 것 같습니다!

## 연결된 이슈

## 자료 (스크린샷 등)
