### PR TITLE
feat: 고양이 품종 정보 조회(전체, 특정) API 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
@@ -16,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import javax.validation.constraints.Positive;
 import java.util.List;
 
 @RestController
@@ -48,7 +49,7 @@ public class CatInfoController {
 
     @Operation(summary = "모든 고양이 품종 정보 불러오기", description = "고양이 등록 시 품종 선택에 사용하는 api 입니다. 모든 데이터를 가져오지만 페이지네이션은 적절치 않아 사용하지 않습니다.",
             responses = {
-                @ApiResponse(responseCode = "200", description = "모든 품종 정보 조회 성공")
+                    @ApiResponse(responseCode = "200", description = "모든 품종 정보 조회 성공")
             }
     )
     @GetMapping()
@@ -56,5 +57,17 @@ public class CatInfoController {
         List<CatInfo> catInfos = catInfoService.findAllCatInfo();
 
         return new ResponseEntity<>(catInfoMapper.catInfosToCatInfoSimpleDtos(catInfos), HttpStatus.OK);
+    }
+
+    @Operation(summary = "특정 고양이 품종 정보 조회", description = "특정 고양이 품종 페이지에 사용되는 api 입니다. 엔드포인트로 품종의 한국어 이름을 보내주셔야 합니다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "특정 품종 정보 조회 성공"),
+                    @ApiResponse(responseCode = "404", description = "찾을 수 없는 품종 정보")
+            }
+    )
+    @GetMapping("{breeds-id}")
+    public ResponseEntity getCatInfo(@PathVariable("breeds-id") @Positive long catInfoId) {
+        CatInfo findCatInfo = catInfoService.findById(catInfoId);
+        return new ResponseEntity<>(catInfoMapper.catInfoToCatInfoResponseDto(findCatInfo), HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
@@ -36,7 +36,7 @@ public class CatInfoController {
             responses = {
                     @ApiResponse(responseCode = "201", description = "고양이 품종 정보 생성 성공",
                             content = @Content(schema = @Schema(implementation = FeedCommentGetDto.class))),
-                    @ApiResponse(responseCode = "409", description = "이미 등록되어 있는 품종(korName)")
+                    @ApiResponse(responseCode = "409", description = "이미 등록되어 있는 품종(korName이 이미 등록되어 있는 경우 에러 발생)")
             }
     )
     @PostMapping
@@ -46,7 +46,11 @@ public class CatInfoController {
         return new ResponseEntity<>(catInfoMapper.catInfoToCatInfoResponseDto(createCatInfo), HttpStatus.CREATED);
     }
 
-    @Operation(summary = "모든 고양이 품종 정보 불러오기", description = "고양이 등록 시 품종 선택에 사용하는 api 입니다. 페이지네이션 적절치 않아 사용하지 않습니다.")
+    @Operation(summary = "모든 고양이 품종 정보 불러오기", description = "고양이 등록 시 품종 선택에 사용하는 api 입니다. 모든 데이터를 가져오지만 페이지네이션은 적절치 않아 사용하지 않습니다.",
+            responses = {
+                @ApiResponse(responseCode = "200", description = "모든 품종 정보 조회 성공")
+            }
+    )
     @GetMapping()
     public ResponseEntity getCatInfos() {
         List<CatInfo> catInfos = catInfoService.findAllCatInfo();

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
@@ -16,6 +16,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.List;
 
 @RestController
 @RequestMapping("/집사생활/cats")
@@ -45,9 +46,11 @@ public class CatInfoController {
         return new ResponseEntity<>(catInfoMapper.catInfoToCatInfoResponseDto(createCatInfo), HttpStatus.CREATED);
     }
 
-    @GetMapping
+    @Operation(summary = "모든 고양이 품종 정보 불러오기", description = "고양이 등록 시 품종 선택에 사용하는 api 입니다. 페이지네이션 적절치 않아 사용하지 않습니다.")
+    @GetMapping()
     public ResponseEntity getCatInfos() {
-        return new ResponseEntity<>(HttpStatus.OK);
-    }
+        List<CatInfo> catInfos = catInfoService.findAllCatInfo();
 
+        return new ResponseEntity<>(catInfoMapper.catInfosToCatInfoSimpleDtos(catInfos), HttpStatus.OK);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/controller/CatInfoController.java
@@ -59,13 +59,13 @@ public class CatInfoController {
         return new ResponseEntity<>(catInfoMapper.catInfosToCatInfoSimpleDtos(catInfos), HttpStatus.OK);
     }
 
-    @Operation(summary = "특정 고양이 품종 정보 조회", description = "특정 고양이 품종 페이지에 사용되는 api 입니다. 엔드포인트로 품종의 한국어 이름을 보내주셔야 합니다.",
+    @Operation(summary = "특정 고양이 품종 정보 조회", description = "특정 고양이 품종 페이지에 사용되는 api 입니다.",
             responses = {
                     @ApiResponse(responseCode = "200", description = "특정 품종 정보 조회 성공"),
                     @ApiResponse(responseCode = "404", description = "찾을 수 없는 품종 정보")
             }
     )
-    @GetMapping("{breeds-id}")
+    @GetMapping("/{breeds-id}")
     public ResponseEntity getCatInfo(@PathVariable("breeds-id") @Positive long catInfoId) {
         CatInfo findCatInfo = catInfoService.findById(catInfoId);
         return new ResponseEntity<>(catInfoMapper.catInfoToCatInfoResponseDto(findCatInfo), HttpStatus.OK);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
@@ -8,6 +8,9 @@ import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 import org.springframework.validation.annotation.Validated;
 
+import javax.validation.Valid;
+import java.util.List;
+
 @NoArgsConstructor
 @AllArgsConstructor
 @Getter
@@ -31,4 +34,7 @@ public class CatInfoPostDto {
 
     @Length(max = 1000)
     private String features;
+
+    @Valid
+    private List<DiseaseDto> disease;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
@@ -42,6 +42,12 @@ public class CatInfoPostDto {
     @Length(max = 1000)
     private String features;
 
+    @ApiModelProperty(value = "고양이 품종 정보 페이지에 보여주는지 여부", example = "false")
+    private boolean showCatInfo;
+
+    @ApiModelProperty(value = "고양이 품종 사진 경로", example = "https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/catvillage/images/dccf3d4d")
+    private String picture;
+
     @ApiModelProperty(value = "취약한 질병 리스트")
     @Valid
     private List<DiseaseDto> diseases;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoPostDto.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.catInfo.dto;
 
+import io.swagger.annotations.ApiModelProperty;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -17,24 +18,31 @@ import java.util.List;
 @Setter
 @Validated
 public class CatInfoPostDto {
+    @ApiModelProperty(value = "한국어 이름(길이 20자 제한)", example = "셀커크 렉스")
     @Length(max = 20)
     private String korName;
 
+    @ApiModelProperty(value = "영어 이름(길이 20자 제한", example = "Selkirk Rex")
     @Length(max = 20)
     private String engName;
 
+    @ApiModelProperty(value = "성격 특징(길이 1000자 제한", example = "애교가 많고 외로움을 많이 탑니다.")
     @Length(max = 1000)
     private String character;
 
+    @ApiModelProperty(value = "털길이 0~3(0: 털 없음, 1: 단모, 2: 중모, 3: 장모)", example = "2")
     @Range(max = 3, min = 0)
     private Short hairLength;
 
+    @ApiModelProperty(value = "털길이 0~3(0: 털 없음, 1: 단모, 2: 중모, 3: 장모)", example = "2")
     @Range(max = 3, min = 0)
     private Short hairLoss;
 
+    @ApiModelProperty(value = "그외 특징", example = "코가 낮습니다.")
     @Length(max = 1000)
     private String features;
 
+    @ApiModelProperty(value = "취약한 질병 리스트")
     @Valid
-    private List<DiseaseDto> disease;
+    private List<DiseaseDto> diseases;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoResponseDto.java
@@ -1,20 +1,37 @@
 package com.twentyfour_seven.catvillage.catInfo.dto;
 
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import io.swagger.annotations.ApiModelProperty;
+import lombok.*;
+
+import java.util.List;
 
 @Getter
 @Setter
 @NoArgsConstructor
 @AllArgsConstructor
+@Builder
 public class CatInfoResponseDto {
+    @ApiModelProperty(value = "품종 식별자", example = "1")
     private Long catInfoId;
+
+    @ApiModelProperty(value = "한국어 이름", example = "셀커크렉스")
     private String korName;
+
+    @ApiModelProperty(value = "영어 이름", example = "Selkirk Rex")
     private String engName;
+
+    @ApiModelProperty(value = "성격 특징", example = "애교가 많고 외로움을 많이 탑니다.")
     private String character;
+
+    @ApiModelProperty(value = "털길이 0~3(0: 털 없음, 1: 단모, 2: 중모, 3: 장모)", example = "2")
     private Short hairLength;
+
+    @ApiModelProperty(value = "털빠짐 0~3(0: 털 없음, 1: 적음, 2: 중간, 3: 많음)", example = "2")
     private Short hairLoss;
+
+    @ApiModelProperty(value = "그외 특징", example = "코가 낮습니다.")
     private String features;
+
+    @ApiModelProperty(value = "취약한 질병 리스트")
+    private List<DiseaseDto> diseases;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoResponseDto.java
@@ -32,6 +32,12 @@ public class CatInfoResponseDto {
     @ApiModelProperty(value = "그외 특징", example = "코가 낮습니다.")
     private String features;
 
+    @ApiModelProperty(value = "고양이 품종 사진 경로", example = "https://catvillage-image-server.s3.ap-northeast-2.amazonaws.com/catvillage/images/dccf3d4d")
+    private String picture;
+
+    @ApiModelProperty(value = "고양이 품종 정보 페이지에 보여주는지 여부", example = "false")
+    private Boolean showCatInfo;
+
     @ApiModelProperty(value = "취약한 질병 리스트")
     private List<DiseaseDto> diseases;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoSimpleDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/CatInfoSimpleDto.java
@@ -1,0 +1,16 @@
+package com.twentyfour_seven.catvillage.catInfo.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@NoArgsConstructor
+@AllArgsConstructor
+@Getter
+@Setter
+public class CatInfoSimpleDto {
+    private Long catInfoId;
+    private String korName;
+    private String engName;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/DiseaseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/dto/DiseaseDto.java
@@ -1,0 +1,15 @@
+package com.twentyfour_seven.catvillage.catInfo.dto;
+
+import lombok.*;
+import org.hibernate.validator.constraints.Length;
+import org.springframework.validation.annotation.Validated;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Validated
+public class DiseaseDto {
+    @Length(max = 30)
+    private String name;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/CatInfo.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/entity/CatInfo.java
@@ -40,6 +40,9 @@ public class CatInfo {
     @Column(name = "SHOW_CAT_INFO", nullable = false)
     private boolean showCatInfo;
 
+    @Column(name = "PICTURE")
+    private String picture;
+
     @OneToMany(mappedBy = "catInfo")
     @JsonManagedReference
     List<Cat> cats = new ArrayList<>();
@@ -50,7 +53,7 @@ public class CatInfo {
 
     @Builder
     public CatInfo(String korName, String engName, String character, Short hairLength, Short hairLoss,
-                   String features, boolean showCatInfo) {
+                   String features, boolean showCatInfo, String picture) {
         this.korName = korName;
         this.engName = engName;
         this.character = character;
@@ -58,5 +61,6 @@ public class CatInfo {
         this.hairLoss = hairLoss;
         this.features = features;
         this.showCatInfo = showCatInfo;
+        this.picture = picture;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/mapper/CatInfoMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/mapper/CatInfoMapper.java
@@ -2,14 +2,52 @@ package com.twentyfour_seven.catvillage.catInfo.mapper;
 
 import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoPostDto;
 import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoResponseDto;
+import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoSimpleDto;
+import com.twentyfour_seven.catvillage.catInfo.dto.DiseaseDto;
 import com.twentyfour_seven.catvillage.catInfo.entity.CatInfo;
+import com.twentyfour_seven.catvillage.catInfo.entity.Disease;
+import com.twentyfour_seven.catvillage.catInfo.entity.DiseaseToCat;
 import org.mapstruct.Mapper;
 import org.mapstruct.ReportingPolicy;
+
+import java.util.List;
 
 @Mapper(componentModel = "spring", unmappedTargetPolicy = ReportingPolicy.IGNORE)
 public interface CatInfoMapper {
 
     CatInfo catInfoPostDtoToCatInfo(CatInfoPostDto catInfoPostDto);
 
-    CatInfoResponseDto catInfoToCatInfoResponseDto(CatInfo catInfo);
+    default CatInfoResponseDto catInfoToCatInfoResponseDto(CatInfo catInfo) {
+        if (catInfo == null)    return null;
+        List<DiseaseDto> diseaseDtos = diseasesToDiseaseDtos(diseaseToCatsToDiseases(catInfo.getDiseaseToCats()));
+        return CatInfoResponseDto.builder()
+                .catInfoId(catInfo.getCatInfoId())
+                .korName(catInfo.getKorName())
+                .engName(catInfo.getEngName())
+                .character(catInfo.getCharacter())
+                .hairLength(catInfo.getHairLength())
+                .hairLoss(catInfo.getHairLoss())
+                .features(catInfo.getFeatures())
+                .diseases(diseaseDtos).build();
+    }
+
+    List<CatInfoResponseDto> catInfosToCatInfoResponseDtos(List<CatInfo> catInfos);
+    default DiseaseDto diseaseToDiseaseDto(Disease disease) {
+        if (disease == null)    return null;
+        return new DiseaseDto(disease.getName());
+    }
+    List<DiseaseDto> diseasesToDiseaseDtos(List<Disease> disease);
+
+    default Disease diseaseToCatToDisease(DiseaseToCat diseaseToCat) {
+        if (diseaseToCat == null) return null;
+        return diseaseToCat.getDisease();
+    }
+    List<Disease> diseaseToCatsToDiseases(List<DiseaseToCat> diseaseToCats);
+
+    default CatInfoSimpleDto catInfoToCatInfoSimpleDto(CatInfo catInfo) {
+        if (catInfo == null) return null;
+        return new CatInfoSimpleDto(catInfo.getCatInfoId(), catInfo.getKorName(), catInfo.getEngName());
+    }
+
+    List<CatInfoSimpleDto> catInfosToCatInfoSimpleDtos(List<CatInfo> catInfos);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/mapper/CatInfoMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/mapper/CatInfoMapper.java
@@ -28,7 +28,10 @@ public interface CatInfoMapper {
                 .hairLength(catInfo.getHairLength())
                 .hairLoss(catInfo.getHairLoss())
                 .features(catInfo.getFeatures())
-                .diseases(diseaseDtos).build();
+                .diseases(diseaseDtos)
+                .picture(catInfo.getPicture())
+                .showCatInfo(catInfo.isShowCatInfo())
+                .build();
     }
 
     List<CatInfoResponseDto> catInfosToCatInfoResponseDtos(List<CatInfo> catInfos);

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/service/CatInfoService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/service/CatInfoService.java
@@ -36,4 +36,8 @@ public class CatInfoService {
     public CatInfo findVerifiedCatInfo(String korName) {
         return catInfoRepository.findByKorName(korName).orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
     }
+
+    public CatInfo findById(long catInfoId) {
+        return catInfoRepository.findById(catInfoId).orElseThrow(() -> new BusinessLogicException(ExceptionCode.BREED_NOT_FOUND));
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/service/CatInfoService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/catInfo/service/CatInfoService.java
@@ -6,6 +6,8 @@ import com.twentyfour_seven.catvillage.exception.BusinessLogicException;
 import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+
 @Service
 public class CatInfoService {
 
@@ -18,6 +20,10 @@ public class CatInfoService {
     public CatInfo createCatInfo(CatInfo catInfo) {
         verifiedExistKorName(catInfo.getKorName());
         return catInfoRepository.save(catInfo);
+    }
+
+    public List<CatInfo> findAllCatInfo() {
+        return catInfoRepository.findAll();
     }
 
     private void verifiedExistKorName(String korName) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -7,6 +7,10 @@ import com.twentyfour_seven.catvillage.board.dto.BoardPostResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.comment.BoardCommentPostResponseDto;
 import com.twentyfour_seven.catvillage.board.dto.comment.BoardUserCommentResponseDto;
 import com.twentyfour_seven.catvillage.cat.dto.*;
+import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoPostDto;
+import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoResponseDto;
+import com.twentyfour_seven.catvillage.catInfo.dto.CatInfoSimpleDto;
+import com.twentyfour_seven.catvillage.catInfo.dto.DiseaseDto;
 import com.twentyfour_seven.catvillage.dto.MultiBoardResponseDto;
 import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.*;
@@ -72,7 +76,11 @@ public class SwaggerConfig {
                         typeResolver.resolve(FollowingResponseDto.class),
                         typeResolver.resolve(CatUserResponseDto.class),
                         typeResolver.resolve(CatSimpleDto.class),
-                        typeResolver.resolve(FeedSimpleDto.class)
+                        typeResolver.resolve(FeedSimpleDto.class),
+                        typeResolver.resolve(CatInfoPostDto.class),
+                        typeResolver.resolve(CatInfoResponseDto.class),
+                        typeResolver.resolve(DiseaseDto.class),
+                        typeResolver.resolve(CatInfoSimpleDto.class)
                 )
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())


### PR DESCRIPTION
## 주요 변경 사항
- DiseaseDto 구현 및 질병 이름 담을 name 변수 필드에 추가
- CatInfoPostDto에 DiseaseDto List 추가
- CatInfoController 및 Service에 모든 품종 정보 가져오기 API 구현
- SwaggerConfig에 구현한 DTO 추가
- CatInfoController 및 Service에 특정 품종 정보 가져오기 API 구현
- CatInfo 엔티티에 Picture 추가
- CatInfoPostDto에 picture 및 showCatInfo 변수 추가

## 코드 변경 이유
- 고양이 품종 정보 작성 요청 시 질병 정보를 담는 변수가 없어 질병 dto 작성하였고 리스트로 가지고 있도록 작성하였습니다.
- 고양이 프로필 등록 페이지에 모든 고양이 품종 정보가 필요하여 API 구현했습니다.
- 특정 고양이 품종 정보 페이지에 필요한 특정 품종 정보 보는 API 구현했습니다. CatInfo Id를 통해 조회합니다.
- 설계에 맞춰 CatInfo 테이블에 PICTURE 칼럼이 추가되어서 CatInfo 엔티티에도 적용했습니다.
- 차후에 관리자 모드(인가) 등 확장성을 고려하여 고양이 품종정보 페이지에 보여지는지 여부(showCatInfo)를 postDto에 추가하였습니다.
  - update 요청 구현 시도 showCatInfo를 받도록 구현 필요합니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 조회 로직이 잘못되진 않았는지
- 변수 명, 메서드 명이 모호하지 않고 적절한지
- CatInfo 엔티티에 변수 추가한 부분
- DTO, mapper에 누락된 변수는 없는지

## 연결된 이슈
- close #207 
- close #314 
- close #206

## 자료 (스크린샷 등)
