### PR TITLE
fix: picture에 유효성검증 정규표현식 버그 fix

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/picture/dto/PictureDto.java
@@ -15,7 +15,7 @@ import javax.validation.constraints.Pattern;
 @NoArgsConstructor
 @Validated
 public class PictureDto {
-    @Pattern(regexp = "^((https?|http?|)://)$")
+    @Pattern(regexp = "^http[s]{0,1}://.*")
     @Length(max = 500)
     private String picture;
 


### PR DESCRIPTION
## 주요 변경 사항
- PictureDto에 picture 정규표현식 수정

## 코드 변경 이유
- 이전에 Picture에 유효성 검증하는 정규표현식이 잘못되어 post-집사생활에서 400, bad request 에러가 발생하여 수정했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분

## 연결된 이슈

## 자료 (스크린샷 등)
