### PR TITLE
fix: 냥이생활 피드 반환 데이터에 isMyFeed 데이터 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -86,7 +86,7 @@ public class FeedController {
         List<FeedTag> feedTags = feedTagService.findFeedTags(findFeed);
         List<FeedComment> comments = feedCommentService.findComments(findFeed);
 
-        FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(findFeed);
+        FeedGetResponseDto response = feedMapper.feedToFeedGetResponseDto(findFeed, user != null ? user.getUsername() : null);
 
         // 로그인되어 있다면 유저가 해당 피드에 좋아요를 눌렀는지 확인
         if (user != null) {

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedGetResponseDto.java
@@ -28,6 +28,9 @@ public class FeedGetResponseDto {
     @ApiParam(value = "요청을 보낸 사용자가 피드에 좋아요를 눌렀는지 여부, 좋아요를 추가했을 경우 true", example = "false")
     private Boolean isLike;
 
+    @ApiParam(value = "요청을 보낸 사용자가 작성한 피드인지 여부, 작성한 피드인 경우 true", example = "false")
+    private Boolean isMyFeed;
+
     @ApiParam(value = "피드에 작성한 글", example = "수라는 잠이 많아요")
     private String body;
 

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
@@ -17,8 +17,8 @@ public class FeedMultiGetResponseDto {
     private String image;
     @ApiParam(value = "로그인한 사용자가 좋아요를 눌렀는지 여부")
     private Boolean isLike;
-    @ApiParam(value = "로그인한 사용자가 작성한 피드인지 여부")
-    private Boolean isMyFeed;
+//    @ApiParam(value = "로그인한 사용자가 작성한 피드인지 여부")
+//    private Boolean isMyFeed;
 
     public FeedMultiGetResponseDto(long feedId, String image) {
         this.feedId = feedId;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiGetResponseDto.java
@@ -17,6 +17,8 @@ public class FeedMultiGetResponseDto {
     private String image;
     @ApiParam(value = "로그인한 사용자가 좋아요를 눌렀는지 여부")
     private Boolean isLike;
+    @ApiParam(value = "로그인한 사용자가 작성한 피드인지 여부")
+    private Boolean isMyFeed;
 
     public FeedMultiGetResponseDto(long feedId, String image) {
         this.feedId = feedId;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -43,12 +43,16 @@ public interface FeedMapper {
         return feed;
     }
 
-    default FeedGetResponseDto feedToFeedGetResponseDto(Feed feed) {
+    default FeedGetResponseDto feedToFeedGetResponseDto(Feed feed, String email) {
         if (feed == null) {
             return null;
         }
 
         List<PictureDto> pictureDtos = new ArrayList<>();
+        boolean isMyFeed = false;
+        if(email != null) {
+            isMyFeed = feed.getCat().getUser().getEmail().equals(email);
+        }
 
         // picture가 있다면 pictureDto로 변환
         if(!feed.getPictures().isEmpty()) {
@@ -66,6 +70,7 @@ public interface FeedMapper {
                 .likeCount(feed.getLikeCount())
                 .build();
         feedGetResponseDto.setPictures(pictureDtos);
+        feedGetResponseDto.setIsMyFeed(isMyFeed);
         return feedGetResponseDto;
     }
 
@@ -82,10 +87,13 @@ public interface FeedMapper {
 
         // 피드마다 좋아요 여부 저장
         boolean isLike = false;
+        boolean isMyFeed = false;
         if (email != null) {
             isLike = feed.getLikes().stream().anyMatch(like -> like.getUser().getEmail().equals(email));
+            isMyFeed = feed.getCat().getUser().getEmail().equals(email);
         }
         feedMultiGetResponseDto.setIsLike(isLike);
+        feedMultiGetResponseDto.setIsMyFeed(isMyFeed);
 
         return feedMultiGetResponseDto;
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/mapper/FeedMapper.java
@@ -87,13 +87,13 @@ public interface FeedMapper {
 
         // 피드마다 좋아요 여부 저장
         boolean isLike = false;
-        boolean isMyFeed = false;
+//        boolean isMyFeed = false;
         if (email != null) {
             isLike = feed.getLikes().stream().anyMatch(like -> like.getUser().getEmail().equals(email));
-            isMyFeed = feed.getCat().getUser().getEmail().equals(email);
+//            isMyFeed = feed.getCat().getUser().getEmail().equals(email);
         }
         feedMultiGetResponseDto.setIsLike(isLike);
-        feedMultiGetResponseDto.setIsMyFeed(isMyFeed);
+//        feedMultiGetResponseDto.setIsMyFeed(isMyFeed);
 
         return feedMultiGetResponseDto;
     }


### PR DESCRIPTION
## 주요 변경 사항
- 냥이생활의 특정 피드 및 전체 피드 조회 시 반환 받는 데이터에 "isMyFeed" 데이터 추가

## 코드 변경 이유
- "삭제하기" 기능의 UI 출력 여부를 판단하기 위한 데이터가 필요하여 추가하기 위해 코드 수정

## 코드 리뷰 시 중점적으로 봐야할 부분
- 코드 로직에 문제가 없는지 확인 부탁드립니다.

## 연결된 이슈
fixed #329

## 자료 (스크린샷 등)
