### PR TITLE
feat: 냥이생활 피드 작성 시 로그인된 유저의 모든 고양이 프로필 정보를 받아오는 API 구현

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/config/SwaggerConfig.java
@@ -16,18 +16,17 @@ import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.*;
 import com.twentyfour_seven.catvillage.security.dto.TokenDto;
 import com.twentyfour_seven.catvillage.user.dto.*;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowGetResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowerResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowingResponseDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpHeaders;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 import springfox.documentation.builders.ApiInfoBuilder;
-import springfox.documentation.builders.ParameterBuilder;
 import springfox.documentation.builders.PathSelectors;
 import springfox.documentation.builders.RequestHandlerSelectors;
-import springfox.documentation.schema.ModelRef;
 import springfox.documentation.service.ApiInfo;
-import springfox.documentation.service.Parameter;
 import springfox.documentation.spi.DocumentationType;
 import springfox.documentation.spring.web.plugins.Docket;
 
@@ -80,7 +79,8 @@ public class SwaggerConfig {
                         typeResolver.resolve(CatInfoPostDto.class),
                         typeResolver.resolve(CatInfoResponseDto.class),
                         typeResolver.resolve(DiseaseDto.class),
-                        typeResolver.resolve(CatInfoSimpleDto.class)
+                        typeResolver.resolve(CatInfoSimpleDto.class),
+                        typeResolver.resolve(UserCatResponseDto.class)
                 )
                 .useDefaultResponseMessages(false)
                 .apiInfo(apiInfo())

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -10,7 +10,7 @@ import com.twentyfour_seven.catvillage.feed.mapper.FeedTagMapper;
 import com.twentyfour_seven.catvillage.feed.service.FeedCommentService;
 import com.twentyfour_seven.catvillage.feed.service.FeedService;
 import com.twentyfour_seven.catvillage.feed.service.FeedTagService;
-import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowFeedGetDto;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.media.Content;
 import io.swagger.v3.oas.annotations.media.Schema;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/dto/FeedMultiResponseDto.java
@@ -1,6 +1,6 @@
 package com.twentyfour_seven.catvillage.feed.dto;
 
-import com.twentyfour_seven.catvillage.user.dto.FollowFeedGetDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowFeedGetDto;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserCatResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/UserCatResponseDto.java
@@ -1,0 +1,14 @@
+package com.twentyfour_seven.catvillage.user.dto;
+
+import lombok.*;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@AllArgsConstructor
+@Builder
+public class UserCatResponseDto {
+    private Long catId;
+    private String name;
+    private String profileImage;
+}

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowFeedGetDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowFeedGetDto.java
@@ -1,4 +1,4 @@
-package com.twentyfour_seven.catvillage.user.dto;
+package com.twentyfour_seven.catvillage.user.dto.follow;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowGetResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowGetResponseDto.java
@@ -1,4 +1,4 @@
-package com.twentyfour_seven.catvillage.user.dto;
+package com.twentyfour_seven.catvillage.user.dto.follow;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowResponseDto.java
@@ -1,4 +1,4 @@
-package com.twentyfour_seven.catvillage.user.dto;
+package com.twentyfour_seven.catvillage.user.dto.follow;
 
 import lombok.Builder;
 import lombok.Getter;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowerResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowerResponseDto.java
@@ -1,4 +1,4 @@
-package com.twentyfour_seven.catvillage.user.dto;
+package com.twentyfour_seven.catvillage.user.dto.follow;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowingResponseDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/dto/follow/FollowingResponseDto.java
@@ -1,4 +1,4 @@
-package com.twentyfour_seven.catvillage.user.dto;
+package com.twentyfour_seven.catvillage.user.dto.follow;
 
 import lombok.Getter;
 import lombok.NoArgsConstructor;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/FollowMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/FollowMapper.java
@@ -1,7 +1,7 @@
 package com.twentyfour_seven.catvillage.user.mapper;
 
-import com.twentyfour_seven.catvillage.user.dto.FollowGetResponseDto;
-import com.twentyfour_seven.catvillage.user.dto.FollowResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowGetResponseDto;
+import com.twentyfour_seven.catvillage.user.dto.follow.FollowResponseDto;
 import com.twentyfour_seven.catvillage.user.entity.Follow;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.mapstruct.Mapper;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/user/mapper/UserMapper.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.user.mapper;
 
+import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.user.dto.*;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.mapstruct.Mapper;
@@ -98,4 +99,18 @@ public interface UserMapper {
             return new UserMyInfoDto(user.getUserId(), user.getName(), user.getProfileImage());
         }
     }
+
+
+    default UserCatResponseDto catToUserCatResponseDto(Cat cat) {
+        if (cat == null) {
+            return null;
+        } else {
+            return UserCatResponseDto.builder()
+                    .catId(cat.getCatId())
+                    .name(cat.getName())
+                    .profileImage(cat.getImage())
+                    .build();
+        }
+    }
+    List<UserCatResponseDto> catsToUserCatResponseDtos(List<Cat> cat);
 }


### PR DESCRIPTION
## 주요 변경 사항
- 냥이생활 피드 작성 페이지에 사용될 로그인 된 유저의 고양이 프로필 조회 API에 사용될 응답 Dto 생성
- Mapper에 cat 리스트를 응답 dto로 변환하는 메서드 생성
- user/dto 패키지내 follow 패키지 생성하여 follow 관련 dto 분리
- UserController에 CatService 주입하여 findCatsByUser 메서드 호출
- UserController에 getCats 구현

## 코드 변경 이유
- user 패키지 내 dto가 많아져 follow 패키지 생성하여 리팩토링 하였습니다.
- 냥이생활 피드 작성 시 로그인된 유저 정보를 이용해 모든 고양이 프로필의 id, name, profileImage를 반환하는 API를 생성했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 로직 상 틀린 부분은 없는지
- 오타가 없는지

## 연결된 이슈
- close #319 

## 자료 (스크린샷 등)
