### PR TITLE
[FE] isLogin 상태 타입 에러에 해결 방법 적용

### DIFF
--- a/client/src/pages/Feed/Feeds/Feeds.tsx
+++ b/client/src/pages/Feed/Feeds/Feeds.tsx
@@ -25,16 +25,16 @@ const Feeds = () => {
   }, [])
 
   const handleLikeClick = (feedId: number, isLike: boolean) => {
-    if (isLogin) {
-      if (isLike) {
-        dispatch(cancelLikeAsync(feedId))
-      } else {
-        dispatch(addLikeAsync(feedId))
-      }
-    } else {
+    if (!isLogin) {
       alert('로그인이 필요한 서비스입니다🐱')
-      navigate('/login')
+      return navigate('/login')
     }
+
+    if (!isLike) {
+      return dispatch(addLikeAsync(feedId))
+    }
+
+    return dispatch(cancelLikeAsync(feedId))
   }
 
   return (

--- a/client/src/redux/store/index.ts
+++ b/client/src/redux/store/index.ts
@@ -27,7 +27,7 @@ const rootReducer = combineReducers({
   boards: boardsReducer,
 })
 
-const persistedReducer = persistReducer(persistConfig, rootReducer)
+const persistedReducer = persistReducer<RootState>(persistConfig, rootReducer)
 
 export const setupStore = (preloadedState?: PreloadedState<RootState>) => {
   return configureStore({


### PR DESCRIPTION
## 주요 변경 사항
### 1. 리팩토링
- 로그인 여부를 체크하는 로직이 포함된 ``handleLikeClick`` 함수를 리팩토링했습니다.
- 기존의 코드는 ``if...else``문이 중첩되어 코드의 가독성이 떨어진다고 판단했습니다.
- 따라서 ``Early Return``을 사용해 코드의 가독성을 높이고 명시적으로 리팩토링했습니다.

### 2. isLogin 상태 타입 에러
- ``redux-persist``를 도입해 ``isLogin`` 상태를 사용한 이후로 아래와 같은 에러가 발생하면서 빌드에 실패합니다.
<img width="795" alt="image" src="https://user-images.githubusercontent.com/88873956/200589883-6d00ab51-b300-4962-a7f6-4be552889332.png">

> Property 'isLogin' does not exist on type 'unknown'.

### 2.1. 원인 추측
- 에러가 발생하는 파일 모두 ``isLogin`` 상태를 사용한다는 공통점이 있습니다.
- 따라서 ``redux-persist``를 적용하는 과정에서 타입과 관련된 에러가 발생했다고 생각했습니다.
- 문제 해결을 위해 구글링하던 중, 비슷한 타입 이슈를 발견했습니다.
<img width="927" alt="image" src="https://user-images.githubusercontent.com/88873956/200592564-2d96d676-8fff-4aac-a35b-f6b881f07ed0.png">

[출처: redux-persist on typescript #1140](https://github.com/rt2zz/redux-persist/issues/1140)

### 2.2. 해결 방법 적용
- 따라서 ``persistedReducer``에  ``RootState`` 라는 타입을 지정해보았습니다.

- 만약 이후에도 빌드에 실패하면 다시 원인과 해결 방안을 모색하겠습니다.

## 코드 변경 이유

## 연결된 이슈
#332 

## 자료 (스크린샷 등)
[[클린코드 JS] Else if와 Else를 피하고 Early Return하자](https://velog.io/@jangws/9.-Else-if%EC%99%80-Else%EB%A5%BC-%ED%94%BC%ED%95%98%EA%B3%A0-Early-Return%ED%95%98%EC%9E%90#3-early-return)
[Persist-reducer function giving type error to my reducer in typescript](https://stackoverflow.com/questions/69978434/persist-reducer-function-giving-type-error-to-my-reducer-in-typescript)