### PR TITLE
feat: 집사생활 검색 기능 추가

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/repository/BoardRepository.java
@@ -1,7 +1,15 @@
 package com.twentyfour_seven.catvillage.board.repository;
 
 import com.twentyfour_seven.catvillage.board.entity.Board;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BoardRepository extends JpaRepository<Board, Long> {
+    Page<Board> findByTitleIsContaining(String keyword, Pageable pageable);
+
+    Page<Board> findByBodyIsContaining(String keyword, Pageable pageable);
+
+    Page<Board> findByUserNameIsContaining(String keyword, Pageable pageable);
+//    Page<Board> findByTitleIsContainingOrBodyIsContainingOrUserNameIsContaining(String keyword, Pageable pageable);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/board/service/BoardService.java
@@ -13,6 +13,7 @@ import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
@@ -43,6 +44,42 @@ public class BoardService {
     public Board findBoard(Long boardId) {
         return findVerifiedBoard(boardId);
     }
+
+    public Page<Board> searchBoards(int page, int size, String where, String keyword) {
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("boardId").descending());
+        return keywordFilteringBoard(where, keyword, pageRequest);
+    }
+
+    private Page<Board> keywordFilteringBoard(String where, String keyword, PageRequest pageRequest) {
+        switch (where) {
+//            case "all": return containingAll(keyword, pageRequest);
+//            case "tag":
+//                return
+            case "title":
+                return containingTitle(keyword, pageRequest);
+            case "body":
+                return containingBody(keyword, pageRequest);
+            case "user":
+                return containingUserName(keyword, pageRequest);
+        }
+        return null;
+    }
+
+    private Page<Board> containingTitle(String keyword, Pageable pageable) {
+        return boardRepository.findByTitleIsContaining(keyword, pageable);
+    }
+
+    private Page<Board> containingBody(String keyword, Pageable pageable) {
+        return boardRepository.findByBodyIsContaining(keyword, pageable);
+    }
+
+    private Page<Board> containingUserName(String keyword, Pageable pageable) {
+        return boardRepository.findByUserNameIsContaining(keyword, pageable);
+    }
+
+//    private Page<Board> containingAll(String keyword, Pageable pageable) {
+//        return boardRepository.findByTitleIsContainingOrBodyIsContainingOrUserNameIsContaining(keyword, pageable);
+//    }
 
     public Board createBoard(Board board, List<BoardTagDto> tags, List<PictureDto> pictures) {
         // ID를 얻기 위한 저장 로직


### PR DESCRIPTION
## 주요 변경 사항
- 집사생활 검색 기능 추가
- title, body, user name으로 검색 가능
- all, tag는 이후 추가 필요

## 코드 변경 이유
- 집사생활에 등록된 게시글의 검색 기능을 추가하기 위해 변경
- all은 주석을 풀 경우 에러 발생

## 코드 리뷰 시 중점적으로 봐야할 부분
- title, body, user name에 대한 검색 로직

## 연결된 이슈
resolved #270

## 자료 (스크린샷 등)
