### PR TITLE
feat: 특정 유저가 좋아요 누른 냥이생활 피드 조회 API 구현(페이지네이션 적용)

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeRepository.java
@@ -7,12 +7,16 @@ import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
     boolean existsByUserAndFeed(User user, Feed feed);
+
     void deleteByUserAndFeed(User user, Feed feed);
 
     boolean existsByUserAndBoard(User user, Board board);
+
     void deleteByUserAndBoard(User user, Board board);
 
     boolean existsByUserAndFeedComment(User user, FeedComment feedComment);
@@ -22,4 +26,6 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
     boolean existsByUserAndBoardComment(User user, BoardComment boardComment);
 
     void deleteByUserAndBoardComment(User user, BoardComment boardComment);
+
+    List<Like> findByUserAndFeedIsNotNull(User user);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeRepository.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeRepository.java
@@ -5,9 +5,9 @@ import com.twentyfour_seven.catvillage.board.entity.BoardComment;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
 import com.twentyfour_seven.catvillage.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
-
-import java.util.List;
 
 public interface LikeRepository extends JpaRepository<Like, Long> {
 
@@ -27,5 +27,5 @@ public interface LikeRepository extends JpaRepository<Like, Long> {
 
     void deleteByUserAndBoardComment(User user, BoardComment boardComment);
 
-    List<Like> findByUserAndFeedIsNotNull(User user);
+    Page<Like> findByUserAndFeedIsNotNull(User user, Pageable pageable);
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
@@ -9,6 +9,9 @@ import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import org.springframework.stereotype.Service;
 
+import java.util.List;
+import java.util.stream.Collectors;
+
 @Service
 public class LikeService {
     private final LikeRepository likeRepository;
@@ -95,5 +98,10 @@ public class LikeService {
 
     public boolean findExistLike(Feed feed, User user) {
         return likeRepository.existsByUserAndFeed(user, feed);
+    }
+
+    public List<Feed> findFeedByUserLike(User user) {
+        List<Like> likes = likeRepository.findByUserAndFeedIsNotNull(user);
+        return likes.stream().map(Like::getFeed).collect(Collectors.toList());
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/common/like/LikeService.java
@@ -7,10 +7,9 @@ import com.twentyfour_seven.catvillage.exception.ExceptionCode;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
 import com.twentyfour_seven.catvillage.user.entity.User;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
-
-import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 public class LikeService {
@@ -100,8 +99,8 @@ public class LikeService {
         return likeRepository.existsByUserAndFeed(user, feed);
     }
 
-    public List<Feed> findFeedByUserLike(User user) {
-        List<Like> likes = likeRepository.findByUserAndFeedIsNotNull(user);
-        return likes.stream().map(Like::getFeed).collect(Collectors.toList());
+    public Page<Like> findLikeByUserLike(Pageable pageable, User user) {
+        Page<Like> likePage = likeRepository.findByUserAndFeedIsNotNull(user, pageable);
+        return likePage;
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -287,4 +287,10 @@ public class FeedController {
         List<Feed> feeds = feedService.findFeedByUser(userId);
         return new ResponseEntity<>(feedMapper.feedsToFeedSimpleDtos(feeds), HttpStatus.OK);
     }
+
+    @GetMapping("/users/{users-id}/likes")
+    public ResponseEntity getFeedFromUserLike(@PathVariable("users-id") @Positive long userId) {
+        List<Feed> feeds = feedService.findFeedByLike(userId);
+        return new ResponseEntity<>(feedMapper.feedsToFeedSimpleDtos(feeds), HttpStatus.OK);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/controller/FeedController.java
@@ -1,5 +1,6 @@
 package com.twentyfour_seven.catvillage.feed.controller;
 
+import com.twentyfour_seven.catvillage.dto.MultiResponseDto;
 import com.twentyfour_seven.catvillage.feed.dto.*;
 import com.twentyfour_seven.catvillage.feed.entity.Feed;
 import com.twentyfour_seven.catvillage.feed.entity.FeedComment;
@@ -288,9 +289,20 @@ public class FeedController {
         return new ResponseEntity<>(feedMapper.feedsToFeedSimpleDtos(feeds), HttpStatus.OK);
     }
 
+    @Operation(summary = "특정 유저가 좋아요를 누른 모든 피드 조회", description = "특정 유저의 id를 path에 입력하여 특정 유저가 좋아요 누른 피드 리스트를 페이지네이션으로 반환합니다. (param 기본값 page: 1, size: 10)",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "피드 조회 성공",
+                            content = @Content(schema = @Schema(implementation = FeedSimpleDto.class))),
+                    @ApiResponse(responseCode = "404", description = "존재하지 않는 유저"),
+
+            }
+    )
     @GetMapping("/users/{users-id}/likes")
-    public ResponseEntity getFeedFromUserLike(@PathVariable("users-id") @Positive long userId) {
-        List<Feed> feeds = feedService.findFeedByLike(userId);
-        return new ResponseEntity<>(feedMapper.feedsToFeedSimpleDtos(feeds), HttpStatus.OK);
+    public ResponseEntity getFeedFromUserLike(@PathVariable("users-id") @Positive long userId,
+                                              @RequestParam(defaultValue = "1") @Positive int page,
+                                              @RequestParam(defaultValue = "10") @Positive int size) {
+        Page<Feed> feedPage = feedService.findFeedByLike(userId, page - 1, size);
+        return new ResponseEntity<>(
+                new MultiResponseDto<FeedSimpleDto>(feedMapper.feedsToFeedSimpleDtos(feedPage.getContent()), feedPage), HttpStatus.OK);
     }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -198,4 +198,9 @@ public class FeedService {
         findUser.getCats().forEach(cat -> findFeeds.addAll(feedRepository.findByCat(cat)));
         return findFeeds;
     }
+
+    public List<Feed> findFeedByLike(long userId) {
+        User findUser = userService.findUser(userId);
+        return likeService.findFeedByUserLike(findUser);
+    }
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -200,7 +200,7 @@ public class FeedService {
 
     public Page<Feed> findFeedByLike(long userId, int page, int size) {
         User findUser = userService.findUser(userId);
-        PageRequest pageRequest = PageRequest.of(page, size, Sort.unsorted());
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.by("likeId").descending());
         Page<Like> likePage = likeService.findLikeByUserLike(pageRequest, findUser);
         return new PageImpl<Feed>(likePage.getContent().stream().map(Like::getFeed).collect(Collectors.toList()),
                 likePage.getPageable(), likePage.getTotalElements());

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/feed/service/FeedService.java
@@ -2,6 +2,7 @@ package com.twentyfour_seven.catvillage.feed.service;
 
 import com.twentyfour_seven.catvillage.cat.entity.Cat;
 import com.twentyfour_seven.catvillage.cat.service.CatService;
+import com.twentyfour_seven.catvillage.common.like.Like;
 import com.twentyfour_seven.catvillage.common.like.LikeService;
 import com.twentyfour_seven.catvillage.common.picture.entity.Picture;
 import com.twentyfour_seven.catvillage.common.picture.service.PictureService;
@@ -12,9 +13,7 @@ import com.twentyfour_seven.catvillage.feed.repository.FeedRepository;
 import com.twentyfour_seven.catvillage.user.entity.User;
 import com.twentyfour_seven.catvillage.user.service.FollowService;
 import com.twentyfour_seven.catvillage.user.service.UserService;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.*;
 import org.springframework.stereotype.Service;
 
 import java.util.ArrayList;
@@ -199,8 +198,11 @@ public class FeedService {
         return findFeeds;
     }
 
-    public List<Feed> findFeedByLike(long userId) {
+    public Page<Feed> findFeedByLike(long userId, int page, int size) {
         User findUser = userService.findUser(userId);
-        return likeService.findFeedByUserLike(findUser);
+        PageRequest pageRequest = PageRequest.of(page, size, Sort.unsorted());
+        Page<Like> likePage = likeService.findLikeByUserLike(pageRequest, findUser);
+        return new PageImpl<Feed>(likePage.getContent().stream().map(Like::getFeed).collect(Collectors.toList()),
+                likePage.getPageable(), likePage.getTotalElements());
     }
 }


### PR DESCRIPTION
## 주요 변경 사항
- FeedController에 `냥이생활/users/{users-id}/likes` 엔드포인트로 갖는 특정 유저가 좋아요 누른 냥이생활 피드를 모두 조회하는 API 구현
- 페이지네이션 적용 (MultiResponseDto 사용)
- param 기본값으로 page = 1, size = 10
- FeedController.getFeedFromUserLike() -> FeedService.findFeedByLike() -> LikeService.findLikeByUserLike() -> LikeRepository.findByUserAndFeedIsNotNull() 호출

## 코드 변경 이유
- 유저가 좋아요를 누른 데이터가 많아지는 상황을 고려하여 페이지네이션을 적용했습니다.
- 조회할 때 Like 테이블에서 조회하므로 likeId descending으로 정렬하여 반환 (최신순)
- 좋아요 정보는 Like 테이블에 있기 때문에 서비스 단에서 like service를 호출하여 조회합니다.
- LikeRepository에서 `feed` 가 `not null` 이면서 파라미터로 전달된 `user` 와 일치하는 데이터를 page로 반환하도록 구현
- page의 내용물이 `like` 이므로 like 안의 `feed` 로 변환합니다.
- postman을 통한 테스트 통과했습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 엔드포인트가 적절한지
- 메서드 명이 적절한지
- 잘못된 로직이 없는지

## 연결된 이슈
- close #293 

## 자료 (스크린샷 등)
