### PR TITLE
refactor: header component 분리 제작

### DIFF
--- a/client/src/components/modules/Header/Header.style.ts
+++ b/client/src/components/modules/Header/Header.style.ts
@@ -1,0 +1,36 @@
+import styled, { css } from 'styled-components'
+
+export const TextBox = styled.div`
+  display: inline-block;
+  width: 100%;
+  text-align: center;
+  padding: 0px 50px;
+`
+
+export const HeaderLayout = styled.div<React.CSSProperties>(
+  ({ theme }) => css`
+    background-color: ${theme.color.primary};
+    height: 52px;
+  `,
+)
+export const HeaderBox = styled.div<React.CSSProperties>(
+  ({ theme }) => css`
+    position: fixed;
+    top: 0;
+    left: 0;
+    right: 0;
+    background-color: ${theme.color.white};
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 15px 20px 12px 20px;
+    z-index: 100;
+  `,
+)
+export const ButtonBox = styled.div`
+  width: 24px;
+`
+
+export const MarginBox = styled.div`
+  height: 52px;
+`

--- a/client/src/components/modules/Header/Header.tsx
+++ b/client/src/components/modules/Header/Header.tsx
@@ -1,0 +1,30 @@
+import SvgButton from '@Atoms/SvgButton'
+import { Children, FC } from 'react'
+import { useNavigate } from 'react-router-dom'
+import * as S from './Header.style'
+
+interface Props {
+  children?: React.ReactNode
+  backButtonDisabled?: boolean
+}
+
+const Header: FC<Props> = ({ children, backButtonDisabled }) => {
+  const navigate = useNavigate()
+  const [content, ...buttons] = Children.toArray(children)
+  return (
+    <S.HeaderLayout>
+      <S.HeaderBox>
+        {backButtonDisabled ? (
+          <S.ButtonBox />
+        ) : (
+          <SvgButton icon="Back" onClick={() => navigate(-1)} />
+        )}
+        <S.TextBox>{content}</S.TextBox>
+        <S.ButtonBox>{buttons}</S.ButtonBox>
+      </S.HeaderBox>
+      <S.MarginBox />
+    </S.HeaderLayout>
+  )
+}
+
+export default Header

--- a/client/src/components/modules/Header/index.ts
+++ b/client/src/components/modules/Header/index.ts
@@ -1,0 +1,3 @@
+import Header from './Header'
+
+export default Header

--- a/client/src/components/template/PostForm/PostForm.style.tsx
+++ b/client/src/components/template/PostForm/PostForm.style.tsx
@@ -13,6 +13,9 @@ export const PostFormLayout = styled.form(
 
 export const ImageInputBox = styled.div`
   margin-bottom: 30px;
+  width: 100%;
+  max-width: 450px;
+  margin: auto
 `
 
 export const PostImageInput = styled(ImageInput).attrs({

--- a/client/src/components/template/PostForm/PostForm.tsx
+++ b/client/src/components/template/PostForm/PostForm.tsx
@@ -1,5 +1,4 @@
 import { axiosInstance } from '@Utils/instance'
-import { Back } from '@Assets/icons'
 import { useNavigate } from 'react-router-dom'
 import { FC } from 'react'
 import { FieldErrors, SubmitHandler, useForm } from 'react-hook-form'
@@ -55,12 +54,12 @@ const PostForm: FC<Props> = ({
   }
   return (
     <S.PostFormLayout onSubmit={handleSubmit(onSubmitHandler, onInvalid)}>
-      <S.Header className="header">
+      {/* <S.Header className="header">
         <button type="button" onClick={() => navigate(-1)}>
           <Back />
         </button>
         <span>글쓰기</span>
-      </S.Header>
+      </S.Header> */}
       <S.ImageInputBox>
         <S.PostImageInput
           inputName="image-input"

--- a/client/src/layout/MainLayout.tsx
+++ b/client/src/layout/MainLayout.tsx
@@ -1,3 +1,4 @@
+import Header from '@Modules/Header'
 import TabBar from '@Modules/TabBar'
 import { BOARD_PATH } from '@Routes/board.routes'
 import { FEED_PATH } from '@Routes/feed.routes'
@@ -9,9 +10,11 @@ const SNavLayout = styled.div`
   display: flex;
   justify-content: space-around;
   align-items: center;
-  width: 173px;
+  width: 50%;
+  max-width: 400px;
+  min-width: 173px;
   height: 34px;
-  margin: 15px auto 12px auto;
+  margin: 0 auto;
 
   background: rgba(198, 198, 198, 0.2);
   border-radius: 36px;
@@ -71,7 +74,9 @@ const Nav = () => {
 export const MainLayout = () => {
   return (
     <SMainLayout>
-      <Nav />
+      <Header backButtonDisabled>
+        <Nav />
+      </Header>
       <Outlet />
       <TabBar />
     </SMainLayout>

--- a/client/src/pages/Board/Boards/Boards.style.tsx
+++ b/client/src/pages/Board/Boards/Boards.style.tsx
@@ -1,7 +1,5 @@
 import styled from 'styled-components'
 
-export const BoardLayout = styled.div`
-  padding-bottom: 1000px;
-`
+export const BoardLayout = styled.div``
 export const BoardBox = styled.div``
 export const BoardItem = styled.div``

--- a/client/src/pages/Board/NewBoard/NewBoard.style.ts
+++ b/client/src/pages/Board/NewBoard/NewBoard.style.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const NewBoardLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 20px;
+`

--- a/client/src/pages/Board/NewBoard/NewBoard.tsx
+++ b/client/src/pages/Board/NewBoard/NewBoard.tsx
@@ -4,7 +4,9 @@ import PostForm, { FormValue } from '@Template/PostForm'
 import { SubmitHandler } from 'react-hook-form'
 import { BOARD_PATH } from '@Routes/board.routes'
 import { axiosInstance } from '@Utils/instance'
+import Header from '@Modules/Header'
 import { useAppSelector } from '@/redux/store'
+import * as S from './NewBoard.style'
 
 const NewBoard = () => {
   const { pathname } = useLocation()
@@ -52,6 +54,11 @@ const NewBoard = () => {
     }
   }
 
-  return <PostForm onSubmitHandler={onSubmitHandler} hasTitle imgRequired />
+  return (
+    <S.NewBoardLayout>
+      <Header>집사생활 글쓰기</Header>
+      <PostForm onSubmitHandler={onSubmitHandler} hasTitle imgRequired />
+    </S.NewBoardLayout>
+  )
 }
 export default NewBoard

--- a/client/src/pages/Feed/NewFeed/NewFeed.style.ts
+++ b/client/src/pages/Feed/NewFeed/NewFeed.style.ts
@@ -1,0 +1,8 @@
+import styled from 'styled-components'
+
+export const NewFeedLayout = styled.div`
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  margin-bottom: 20px;
+`

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -3,7 +3,9 @@ import { useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { SubmitHandler } from 'react-hook-form'
 import { FormValue } from '@Template/PostForm/PostForm'
+import Header from '@Modules/Header'
 import { useAppSelector } from '@/redux/store'
+import * as S from './NewFeed.style'
 
 const NewFeed = () => {
   const navigate = useNavigate()
@@ -20,7 +22,12 @@ const NewFeed = () => {
     // do something
   }
 
-  return <PostForm onSubmitHandler={onSubmitHandler} />
+  return (
+    <S.NewFeedLayout>
+      <Header>냥이생활 글쓰기</Header>
+      <PostForm onSubmitHandler={onSubmitHandler} />
+    </S.NewFeedLayout>
+  )
 }
 
 export default NewFeed

--- a/client/src/pages/Profile/Profile.tsx
+++ b/client/src/pages/Profile/Profile.tsx
@@ -1,4 +1,5 @@
 import { useNavigate } from 'react-router-dom'
+import Header from '@Modules/Header'
 import { logoutAsync } from '@/redux/actions/userAction'
 import { useAppDispatch } from '@/redux/store'
 import { persistor } from '../../index'
@@ -20,7 +21,7 @@ const Profile = () => {
   }
   return (
     <>
-      <div>Profile</div>
+      <Header>profile</Header>
       <button type="button" onClick={logoutHandler}>
         logout
       </button>

--- a/client/src/routes/AppRoutes.tsx
+++ b/client/src/routes/AppRoutes.tsx
@@ -15,7 +15,7 @@ const appRoutes: RouteObject = {
   path: '/',
   // element: <Iphone11Pro />,
   // element: <DashBoard />,
-  element: <PresentLayout />,
+  // element: <PresentLayout />,
   children: [
     { path: 'cat', element: <Cat /> },
     mainRoutes,


### PR DESCRIPTION
## 주요 변경 사항
1. Header Component를 분리하여 src/components/modules/Header/Header.tsx에서 관리합니다.

## 코드 변경 이유
1. Header Component를 분리하여 src/components/modules/Header/Header.tsx에서 관리합니다.
```jsx
// 기본적인 사용 방법
<Header>집사생활 글쓰기</Header>
```
```jsx
// 좌측의 뒤로가기 버튼 사용하고 싶지 않을 때
<Header backButtonDisabled>
    버튼 없는 헤더
</Header>
```
```jsx
// 우측에 추가로 버튼을 위치시키고 싶을 때
<Header>
    집사생활 글쓰기
    <Button/>
</Header>
```
- 그에 따라 Profile.tsx, NewBoard,tsx, NewFeed.tsx를 수정하였습니다.
- Header의 `position: fixed`를 사용하여 항상 뷰포트 상단에 위치합니다
- Header는 항상 뷰포트를 기준으로 움직이므로 발표용 레이아웃과 함께 사용할 수 없습니다. 따라서 필요없어진 발표용 레이아웃을 제거하였습니다.
- 

## 코드 리뷰 시 중점적으로 봐야할 부분
[client/src/components/modules/Header/Header.style.ts](https://github.com/codestates-seb/seb39_main_059/pull/349/files#diff-b213896e22d9719b44a36ff19bc14bf7d8c9f6a9c7a5662861ee019d8eead20f)
## 연결된 이슈


## 자료 (스크린샷 등)
<img width="499" alt="스크린샷 2022-11-18 오후 7 00 09" src="https://user-images.githubusercontent.com/96106122/202675020-b51b6787-0035-4427-b431-1637426f9f44.png">