### PR TITLE
[FE] 냥이생활 피드 삭제 기능 구현

### DIFF
--- a/client/src/components/modules/Dropdown/Dropdown.tsx
+++ b/client/src/components/modules/Dropdown/Dropdown.tsx
@@ -1,9 +1,16 @@
+import { FC } from 'react'
 import * as S from './Dropdown.styles'
 
-const Dropdown = () => {
+interface Props {
+  handleDeleteFeed: () => void
+}
+
+const Dropdown: FC<Props> = ({ handleDeleteFeed }) => {
   return (
     <S.Dropdown>
-      <li>삭제하기</li>
+      <li role="presentation" onClick={handleDeleteFeed}>
+        삭제하기
+      </li>
     </S.Dropdown>
   )
 }

--- a/client/src/components/template/FeedDetail/FeedDetail.tsx
+++ b/client/src/components/template/FeedDetail/FeedDetail.tsx
@@ -4,6 +4,9 @@ import Image from '@Atoms/Image'
 import SvgButton from '@Atoms/SvgButton'
 import { FeedDetail } from '@Types/feed'
 import { FC, useState } from 'react'
+import { axiosInstance } from '@Utils/instance'
+import { FEED_PATH } from '@Routes/feed.routes'
+import { useNavigate } from 'react-router-dom'
 import Dropdown from '@Modules/Dropdown'
 import * as S from './FeedDetail.style'
 
@@ -13,11 +16,29 @@ const FeedDetail: FC<FeedDetail> = ({
   profileImage,
   pictures,
   isMyFeed,
+  feedId,
 }) => {
   const [isDropdownView, setIsDropdownView] = useState<boolean | undefined>(
     false,
   )
+  const navigate = useNavigate()
 
+  const handleDeleteFeed = async () => {
+    try {
+      if (window.confirm('삭제하시겠습니까?')) {
+        const axiosResponse = axiosInstance.delete(`${FEED_PATH}/${feedId}`, {
+          headers: {
+            contentType: 'application/json',
+            Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+          },
+        })
+      }
+      alert('삭제되었습니다.')
+      navigate(-1)
+    } catch (error: any) {
+      alert('에러가 발생했습니다 :(')
+    }
+  }
   return (
     <S.FeedDetailLayout>
       <S.InfoBox>
@@ -43,7 +64,7 @@ const FeedDetail: FC<FeedDetail> = ({
               icon="DropdownMenuIcon"
               onClick={() => setIsDropdownView(!isDropdownView)}
             />
-            {isDropdownView && <Dropdown />}
+            {isDropdownView && <Dropdown handleDeleteFeed={handleDeleteFeed} />}
           </S.DropdownBox>
         )}
       </S.InfoBox>


### PR DESCRIPTION
## 주요 변경 사항
- 냥이생활 피드 삭제 기능을 구현했습니다.
- 드롭다운의 ``'삭제하기'``에 ``handleDeleteFeed`` 함수를 전달해 사용자가 클릭하면 해당 함수가 실행됩니다.

## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분
- 삭제 로직과 에러 핸들링이 올바른지, 더 나은 방법이 있는지 확인부탁드립니다.

## 연결된 이슈
#97 

## 자료 (스크린샷 등)
