### PR TITLE
fix: reissue request body에 accessToken 안받도록 API 변경

### DIFF
--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/config/SecurityConfig.java
@@ -52,6 +52,7 @@ public class SecurityConfig {
                 .antMatchers("/signup").permitAll() // 회원가입을 위한 API 는 토큰 없이도 허용
                 .antMatchers(HttpMethod.POST, "/login").permitAll() // 로그인을 위한 API 는 토큰 없이도 허용
                 .antMatchers(HttpMethod.GET, "/**").permitAll() // GET 요청은 토큰 없이도 허용
+                .antMatchers("/reissue").permitAll()    // 토큰 재발급 요청은 엑세스 토큰(만료) 확인하지 않음
                 .antMatchers("/h2/**").permitAll()
                 .anyRequest().authenticated() // 나머지 API 는 모두 인증 필요
                 .and()

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/controller/AuthController.java
@@ -67,10 +67,10 @@ public class AuthController {
             }
     )
     @PostMapping("/logout")
-    public ResponseEntity logout(@RequestBody TokenRequestDto tokenRequestDto,
+    public ResponseEntity logout(@RequestBody TokenDto tokenDto,
                                  @AuthenticationPrincipal User user) {
         if (user != null) {
-            authService.logout(tokenRequestDto);
+            authService.logout(tokenDto);
         }
         return new ResponseEntity<>(HttpStatus.OK);
     }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/dto/TokenDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/dto/TokenDto.java
@@ -2,10 +2,12 @@ package com.twentyfour_seven.catvillage.security.dto;
 
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import lombok.Setter;
 
 @Getter
 @Setter
+@NoArgsConstructor
 @AllArgsConstructor
 public class TokenDto {
     private String accessToken;

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/dto/TokenRequestDto.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/dto/TokenRequestDto.java
@@ -10,6 +10,5 @@ import lombok.Setter;
 @NoArgsConstructor
 @AllArgsConstructor
 public class TokenRequestDto {
-    private String accessToken;
     private String refreshToken;
 }

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
@@ -61,6 +61,7 @@ public class JwtTokenizer {
         Date accessTokenExpiresIn = new Date(now + ACCESS_TOKEN_EXPIRE_TIME);
         return Jwts.builder()
                 .setIssuer(ISSUER)  // "iss": "catVillage"
+                .setHeaderParam("typ", "ATK")   // Header "typ": "ATK"
                 .setClaims(claims)  // JWT에 담는 body
                 .setSubject(authentication.getName())    // JWT 제목 payload "sub": "email"
                 .setIssuedAt(Calendar.getInstance().getTime())  // JWT 발행일자 payload "iat": "발행일자"
@@ -76,6 +77,7 @@ public class JwtTokenizer {
 
         return Jwts.builder()
                 .setIssuer(ISSUER)  // "iss": "catVillage"
+                .setHeaderParam("typ", "RTK") // Header "typ": "RTK"
                 .setSubject(authentication.getName())    // JWT 제목 payload "sub": "email"
                 .setIssuedAt(Calendar.getInstance().getTime())  // JWT 발행일자 payload "iat": "발행일자"
                 .setExpiration(new Date(now + REFRESH_TOKEN_EXPIRE_TIME))  // 만료일자 payload "exp": "발행시간 + 7일"
@@ -113,6 +115,11 @@ public class JwtTokenizer {
         return new UsernamePasswordAuthenticationToken(principal, "", authorities);
     }
 
+    // 리프레쉬 토큰에서 유저 정보(email) 가져오기
+    public String getUserEmail(String refreshToken) {
+        return parseClaims(refreshToken).getSubject();
+    }
+
     // 토큰 정보를 검증
     public boolean validateToken(String token) {
         try {
@@ -128,6 +135,15 @@ public class JwtTokenizer {
             log.info("JWT 토큰이 잘못되었습니다.");
         }
         return false;
+    }
+
+    // Refresh Token 인지 검증
+    public boolean validateRefreshToken(String token) {
+        String tokenType = Jwts.parserBuilder().setSigningKey(key).build().parse(token).getHeader().getType();
+        if (!tokenType.equals("RTK")) {
+            return false;
+        }
+        return true;
     }
 
     // 만료된 토큰이어도 정보를 꺼내는 로직

--- a/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
+++ b/server/catvillage/src/main/java/com/twentyfour_seven/catvillage/security/provider/JwtTokenizer.java
@@ -140,10 +140,7 @@ public class JwtTokenizer {
     // Refresh Token 인지 검증
     public boolean validateRefreshToken(String token) {
         String tokenType = Jwts.parserBuilder().setSigningKey(key).build().parse(token).getHeader().getType();
-        if (!tokenType.equals("RTK")) {
-            return false;
-        }
-        return true;
+        return tokenType.equals("RTK");
     }
 
     // 만료된 토큰이어도 정보를 꺼내는 로직


### PR DESCRIPTION
## 주요 변경 사항
- SecurityConfig에 /reissue 요청 시(모든 http 메서드) 인증 절차 거치지 않도록 코드 추가(permitAll)
- TokenRequestDto에 accessToken 변수 삭제 및 TokenDto에 request 로 사용할 수 있도록 애너테이션 추가
- jwt 토큰 header에 type 정보 추가 및 reissue 요청시 type 검증 로직 추가
- reissue 요청시 request body에 refreshToken만 받도록 수정
- authService에 reissue 로직에서 기존에 accessToken을 받아 인증정보를 가져오던 것을 아래와 같은 순서로 로직 변경
 refreshToken에서 userName을 꺼냄 -> userName으로 UserDetails를 불러옴 -> UserDetails로 authentication 정보 생성 -> 토큰 재발급
- login(토큰 생성), reissue(토큰 재발급) 요청 모두 정상 작동하는지 postman으로 테스트 완료 했습니다.

## 코드 변경 이유
- reissue 요청시 request body에 accessToken과 refreshToken을 모두 받던 것을 만료된 엑세스 토큰을 전달하는 것이 적절하지 않다는 @leejuhanKr  의 의견으로 refreshToken만 받도록 api 수정하였습니다.
- 리프레쉬 토큰을 이용하여 만료된 토큰 재발급 요청 시 액세스 토큰은 만료된 상태이기 때문에 인증 filter를 거치면 401 에러가 발생할 수 있어 인증 필터를 거치지 않도록 수정했습니다.
- TokenRequestDto와 TokenDto 내부 변수가 완전히 동일하여 TokenRequestDto는 reissue 요청시에 요청 바디로 사용하도록 변경했습니다.
- refresh token과 access token의 바디(payload) 정보가 거의 동일하고 쉽게 구분하기 어려워 header에 type 정보를 추가하였습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
- 주요 변경 사항은 AuthService를 보면 됩니다.
- 토큰 관련 로직은 token provider인 Tokenizer 클래스 내부에 작성했습니다.

## 연결된 이슈
#343 

## 자료 (스크린샷 등)
