### PR TITLE
[FE] 냥이생활 피드 작성 기능 추가

### DIFF
--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -1,30 +1,106 @@
 import PostForm from '@Template/PostForm'
-import { useEffect } from 'react'
+import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { SubmitHandler } from 'react-hook-form'
 import { FormValue } from '@Template/PostForm/PostForm'
 import Header from '@Modules/Header'
+import { axiosInstance } from '@Utils/instance'
+import { FEED_PATH } from '@Routes/feed.routes'
 import { useAppSelector } from '@/redux/store'
 import * as S from './NewFeed.style'
+
+interface Props {
+  catId: 0
+  name: string
+  profileImage: string
+}
 
 const NewFeed = () => {
   const navigate = useNavigate()
   const { isLogin } = useAppSelector(state => state.user)
+  const [catInfos, setCatInfos] = useState<Props[]>([])
+  const [catId, setCatId] = useState<number | null>(null)
+
+  const hasCatInfos = (data: any) => {
+    if (!data.length) {
+      if (
+        window.confirm(
+          '고양이를 등록하면 피드를 작성할 수 있습니다.\n등록 페이지로 이동하시겠습니까?',
+        )
+      ) {
+        navigate('/cat')
+      } else {
+        navigate('/')
+      }
+    }
+  }
+
+  const getCatInfos = useCallback(
+    async (callback: any) => {
+      const { data } = await axiosInstance.get('/users/cats', {
+        headers: {
+          contentType: 'application/json',
+          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+        },
+      })
+      setCatInfos(data)
+      callback(data)
+    },
+    [catInfos],
+  )
 
   useEffect(() => {
     if (!isLogin) {
       alert('로그인이 필요한 서비스입니다🐱')
       navigate('/login')
+      return
     }
-  }, [isLogin])
+    getCatInfos(hasCatInfos)
+  }, [])
 
   const onSubmitHandler: SubmitHandler<FormValue> = async data => {
-    // do something
+    const { picture, body } = data
+    const formData = {
+      body,
+      catId,
+      pictures: [
+        {
+          picture,
+        },
+      ],
+      tags: null,
+    }
+    const axiosResponse = await axiosInstance.post(FEED_PATH, formData, {
+      headers: {
+        contentType: 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+      },
+    })
+    navigate(-1)
+    return axiosResponse
   }
+
+  const catList: JSX.Element[] = catInfos.map((catInfo, index) => (
+    // eslint-disable-next-line react/no-array-index-key
+    <option key={index} value={catInfo.catId}>
+      {catInfo.name}
+    </option>
+  ))
 
   return (
     <S.NewFeedLayout>
       <Header>냥이생활 글쓰기</Header>
+      <div>
+        <select
+          onChange={e => {
+            console.log(e.target.value)
+            setCatId(Number(e.target.value))
+          }}
+        >
+          <option value={0}>--고양이 선택--</option>
+          {catList && catList}
+        </select>
+      </div>
       <PostForm onSubmitHandler={onSubmitHandler} />
     </S.NewFeedLayout>
   )

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -19,7 +19,7 @@ const NewFeed: FC = () => {
   const navigate = useNavigate()
   const { isLogin } = useAppSelector(state => state.user)
   const [catInfos, setCatInfos] = useState<Props[]>([])
-  const [catId, setCatId] = useState<number | null>(null)
+  const [catId, setCatId] = useState<number>(0)
 
   const hasCatInfos = <Props,>(data: Props[]) => {
     if (!data.length) {

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -10,7 +10,7 @@ import { useAppSelector } from '@/redux/store'
 import * as S from './NewFeed.style'
 
 interface Props {
-  catId: 0
+  catId: number
   name: string
   profileImage: string
 }

--- a/client/src/pages/Feed/NewFeed/NewFeed.tsx
+++ b/client/src/pages/Feed/NewFeed/NewFeed.tsx
@@ -1,5 +1,5 @@
+import { FC, useEffect, useState } from 'react'
 import PostForm from '@Template/PostForm'
-import { useEffect, useState, useCallback } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { SubmitHandler } from 'react-hook-form'
 import { FormValue } from '@Template/PostForm/PostForm'
@@ -15,13 +15,13 @@ interface Props {
   profileImage: string
 }
 
-const NewFeed = () => {
+const NewFeed: FC = () => {
   const navigate = useNavigate()
   const { isLogin } = useAppSelector(state => state.user)
   const [catInfos, setCatInfos] = useState<Props[]>([])
   const [catId, setCatId] = useState<number | null>(null)
 
-  const hasCatInfos = (data: any) => {
+  const hasCatInfos = <Props,>(data: Props[]) => {
     if (!data.length) {
       if (
         window.confirm(
@@ -35,19 +35,16 @@ const NewFeed = () => {
     }
   }
 
-  const getCatInfos = useCallback(
-    async (callback: any) => {
-      const { data } = await axiosInstance.get('/users/cats', {
-        headers: {
-          contentType: 'application/json',
-          Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
-        },
-      })
-      setCatInfos(data)
-      callback(data)
-    },
-    [catInfos],
-  )
+  const getCatInfos = async (callback: (params: Props[]) => void) => {
+    const { data } = await axiosInstance.get('/users/cats', {
+      headers: {
+        contentType: 'application/json',
+        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+      },
+    })
+    setCatInfos(data)
+    callback(data)
+  }
 
   useEffect(() => {
     if (!isLogin) {
@@ -80,9 +77,8 @@ const NewFeed = () => {
     return axiosResponse
   }
 
-  const catList: JSX.Element[] = catInfos.map((catInfo, index) => (
-    // eslint-disable-next-line react/no-array-index-key
-    <option key={index} value={catInfo.catId}>
+  const catList: JSX.Element[] = catInfos.map(catInfo => (
+    <option key={catInfo.catId} value={catInfo.catId}>
       {catInfo.name}
     </option>
   ))
@@ -93,7 +89,6 @@ const NewFeed = () => {
       <div>
         <select
           onChange={e => {
-            console.log(e.target.value)
             setCatId(Number(e.target.value))
           }}
         >

--- a/client/src/redux/actions/FeedDetailAction.ts
+++ b/client/src/redux/actions/FeedDetailAction.ts
@@ -10,7 +10,11 @@ export const getFeedDetailAsync = createAsyncThunk<
   CreateAsyncThunkTypes
 >('feedDetail/getFeedDetailAsync', async (payload, thunkAPI) => {
   try {
-    const { data } = await axiosInstance.get(`/${FEED_PATH}/${payload}`)
+    const { data } = await axiosInstance.get(`/${FEED_PATH}/${payload}`, {
+      headers: {
+        Authorization: `Bearer ${localStorage.getItem('ACCESS_TOKEN')}`,
+      },
+    })
     return data
   } catch (error: any) {
     return thunkAPI.rejectWithValue(error.message)


### PR DESCRIPTION
## 주요 변경 사항
- 냥이생활 피드 작성 기능을 추가했습니다.
- 냥이생활은 유저의 고양이 프로필로 작성하기 때문에, 고양이 정보를 불러오는 API를 호출합니다.
- 고양이 프로필이 등록되어있지 않은 유저일 경우 고양이 등록 페이지로 이동하는 알림창을 띄웁니다.

## 코드 변경 이유

## 코드 리뷰 시 중점적으로 봐야할 부분
- 고양이 프로필을 선택하는 컴포넌트 (select)를 분리하지 않았습니다.
- 기능 머지 이후 컴포넌트 분리 및 css를 작업할 예정입니다.

## 연결된 이슈
#137 

## 자료 (스크린샷 등)
