### PR TITLE
Feat: axios auth instance 생성

### DIFF
--- a/client/src/api/auth.ts
+++ b/client/src/api/auth.ts
@@ -1,0 +1,14 @@
+import { axiosInstance } from '@Utils/instance'
+
+export const renewAccessToken = async (refreshToken: string) => {
+  const { data } = await axiosInstance.post('/reissue', {
+    refreshToken,
+  })
+  const { accessToken } = data
+
+  if (!accessToken) {
+    throw new Error('토큰을 받지 못했습니다.')
+  }
+
+  return accessToken as string
+}

--- a/client/src/utils/instance.ts
+++ b/client/src/utils/instance.ts
@@ -1,5 +1,80 @@
-import axios from 'axios'
+import axios, { AxiosRequestConfig } from 'axios'
 
 export const axiosInstance = axios.create({
   baseURL: process.env.APP_API,
+  timeout: 5000,
+})
+
+const retrieveUserToken = (tokenName: string) => localStorage.getItem(tokenName)
+
+const setUserToken = (tokenName: string, tokenString: string) =>
+  localStorage.setItem(tokenName, tokenString)
+
+const renewAccessToken = async (refreshToken: string) => {
+  console.log('refreshToken',refreshToken,' 으로 재요청')
+  const { data } = await axiosInstance.post('/reissue', {
+    accessToken: refreshToken,
+    refreshToken,
+  },)
+  const { accessToken } = data
+
+  if (!accessToken) {
+    throw new Error('토큰을 받지 못했습니다.')
+  }
+
+  return accessToken as string
+}
+
+const isTokenExpired = (token: string) => {
+  const [header, payload, sig] = token.split('.')
+
+  if (!(header && payload && sig)) {
+    throw new Error('유효하지 않은 토큰입니다.')
+  }
+  const expiresIn = window.atob(payload).match(/(?<=exp":)\w{1,}/g)
+  const dueToExpire = Number(expiresIn) - Date.now() / 1000 < 5 * 60 // 5분
+
+  return dueToExpire
+}
+
+async function authorizationSetter(config: AxiosRequestConfig) {
+  const header = config.headers!
+
+  if (!header?.tokenNeeded) return config
+
+  let accessToken = retrieveUserToken('ACCESS_TOKEN')
+
+  if (!accessToken) {
+    throw new axios.Cancel(
+      '유저 인증 정보가 존재하지 않습니다. 로그인 상태를 확인하세요.',
+    )
+    // test
+    // const refreshToken = retrieveUserToken('REFRESH_TOKEN')
+    // const renewedAccessToken = await renewAccessToken(refreshToken!)
+    // if (!renewedAccessToken) {
+    //   throw new axios.Cancel()
+    // }
+    // accessToken = renewedAccessToken
+    // setUserToken('ACCESS_TOKEN', accessToken)
+  }
+
+  if (isTokenExpired(accessToken)) {
+    const refreshToken = retrieveUserToken('ACCESS_TOKEN')
+    const renewedAccessToken = await renewAccessToken(refreshToken!)
+    if (!renewedAccessToken) {
+      throw new axios.Cancel()
+    }
+    accessToken = renewedAccessToken
+    setUserToken('ACCESS_TOKEN', accessToken)
+  } 
+
+  delete header.tokenNeeded
+  header.Authorization = `Bearer ${accessToken}`
+
+  return config
+}
+
+axiosInstance.interceptors.request.use(authorizationSetter, function (error) {
+  // Do something with request error
+  return Promise.reject(error)
 })

--- a/client/src/utils/instance.ts
+++ b/client/src/utils/instance.ts
@@ -1,41 +1,11 @@
+import { renewAccessToken } from '@Api/auth'
 import axios, { AxiosRequestConfig } from 'axios'
+import { isTokenExpired, retrieveUserToken, setUserToken } from './tokenControl'
 
 export const axiosInstance = axios.create({
   baseURL: process.env.APP_API,
   timeout: 5000,
 })
-
-const retrieveUserToken = (tokenName: string) => localStorage.getItem(tokenName)
-
-const setUserToken = (tokenName: string, tokenString: string) =>
-  localStorage.setItem(tokenName, tokenString)
-
-const renewAccessToken = async (refreshToken: string) => {
-  console.log('refreshToken',refreshToken,' 으로 재요청')
-  const { data } = await axiosInstance.post('/reissue', {
-    accessToken: refreshToken,
-    refreshToken,
-  },)
-  const { accessToken } = data
-
-  if (!accessToken) {
-    throw new Error('토큰을 받지 못했습니다.')
-  }
-
-  return accessToken as string
-}
-
-const isTokenExpired = (token: string) => {
-  const [header, payload, sig] = token.split('.')
-
-  if (!(header && payload && sig)) {
-    throw new Error('유효하지 않은 토큰입니다.')
-  }
-  const expiresIn = window.atob(payload).match(/(?<=exp":)\w{1,}/g)
-  const dueToExpire = Number(expiresIn) - Date.now() / 1000 < 5 * 60 // 5분
-
-  return dueToExpire
-}
 
 async function authorizationSetter(config: AxiosRequestConfig) {
   const header = config.headers!
@@ -48,14 +18,6 @@ async function authorizationSetter(config: AxiosRequestConfig) {
     throw new axios.Cancel(
       '유저 인증 정보가 존재하지 않습니다. 로그인 상태를 확인하세요.',
     )
-    // test
-    // const refreshToken = retrieveUserToken('REFRESH_TOKEN')
-    // const renewedAccessToken = await renewAccessToken(refreshToken!)
-    // if (!renewedAccessToken) {
-    //   throw new axios.Cancel()
-    // }
-    // accessToken = renewedAccessToken
-    // setUserToken('ACCESS_TOKEN', accessToken)
   }
 
   if (isTokenExpired(accessToken)) {
@@ -66,7 +28,7 @@ async function authorizationSetter(config: AxiosRequestConfig) {
     }
     accessToken = renewedAccessToken
     setUserToken('ACCESS_TOKEN', accessToken)
-  } 
+  }
 
   delete header.tokenNeeded
   header.Authorization = `Bearer ${accessToken}`
@@ -74,7 +36,7 @@ async function authorizationSetter(config: AxiosRequestConfig) {
   return config
 }
 
-axiosInstance.interceptors.request.use(authorizationSetter, function (error) {
+axiosInstance.interceptors.request.use(authorizationSetter, error =>
   // Do something with request error
-  return Promise.reject(error)
-})
+  Promise.reject(error),
+)

--- a/client/src/utils/tokenControl.ts
+++ b/client/src/utils/tokenControl.ts
@@ -1,0 +1,17 @@
+export const retrieveUserToken = (tokenName: string) =>
+  localStorage.getItem(tokenName)
+
+export const setUserToken = (tokenName: string, tokenString: string) =>
+  localStorage.setItem(tokenName, tokenString)
+
+export const isTokenExpired = (token: string) => {
+  const [header, payload, sig] = token.split('.')
+
+  if (!(header && payload && sig)) {
+    throw new Error('유효하지 않은 토큰입니다.')
+  }
+  const expiresIn = window.atob(payload).match(/(?<=exp":)\w{1,}/g)
+  const dueToExpire = Number(expiresIn) - Date.now() / 1000 < 5 * 60 // 5분
+
+  return dueToExpire
+}


### PR DESCRIPTION
## 주요 변경 사항
인증이 필요한 요청에 axiosInstance가 대응할 수 있도록 하였습니다.
이제 헤더에 `tokenNeeded: true`를 설정하면 access token이 header에 담겨 요청됩니다.
access token이 만료되었다면 refresh 토큰을 통해 최신화 시켜준 후 요청을 전송합니다.

## 코드 변경 이유
기존에 인증이 필요한 요청시 일일이 token을 설정해야하는 불편함이 있었습니다.
이를 해결하기 위해 axiosIstance에 로직을 추가해 주었습니다.

## 코드 리뷰 시 중점적으로 봐야할 부분
``` jsx
async function authorizationSetter(config: AxiosRequestConfig) {
  // 헤더에 tokenNeed라는 속성이 있는지 확인
  const header = config.headers!

  // tokenNeed라는 속성이 없다면 그대로 config 반환
  if (!header?.tokenNeeded) return config

  // 있다면 accessToken을 가져옴
  let accessToken = retrieveUserToken('ACCESS_TOKEN')
  
  if (!accessToken) {
    // 에러 핸들링
  }

  //  accessToken 만료시 refreshToken을 사용하여 재발급
  if (isTokenExpired(accessToken)) {
    const refreshToken = retrieveUserToken('ACCESS_TOKEN')
    const renewedAccessToken = await renewAccessToken(refreshToken!)
    if (!renewedAccessToken) {
      throw new axios.Cancel()
    }
    accessToken = renewedAccessToken
    setUserToken('ACCESS_TOKEN', accessToken)
  }

  // tokenNeeded을 header에서 제거하고 accessToken을 header에 추가
  delete header.tokenNeeded
  header.Authorization = `Bearer ${accessToken}`

  return config
}

// 요청이 발생하기전 authorizationSetter를 실행
axiosInstance.interceptors.request.use(authorizationSetter, error =>
  // Do something with request error
  Promise.reject(error),
)
```

## 연결된 이슈

## 자료 (스크린샷 등)
