### PR TITLE
Fix: 냥이생활 피드 상세 페이지 레이아웃 크기 수정

### DIFF
--- a/client/src/pages/Feed/FeedDetail/FeedDetail.tsx
+++ b/client/src/pages/Feed/FeedDetail/FeedDetail.tsx
@@ -7,6 +7,11 @@ import { Back } from '@Assets/icons'
 import { useAppDispatch, useAppSelector } from '@/redux/store'
 import { getFeedDetailAsync } from '@/redux/actions/FeedDetailAction'
 
+const FeedDetailLayout = styled.div`
+  max-width: 768px;
+  margin: 0 auto;
+`
+
 export const Header = styled.div`
   display: grid;
   grid-template-columns: 24px auto 24px;
@@ -15,8 +20,6 @@ export const Header = styled.div`
     margin: auto;
   }
 `
-
-const FeedDetailLayout = styled.div``
 
 const FeedDetail: FC = () => {
   const navigate = useNavigate()


### PR DESCRIPTION
## 주요 변경 사항

- 기존의 화면에 꽉차는 모습 대신 ``max-width``를 주어 최대 크기를 줄였습니다.

## 코드 변경 이유

- 데스크탑에서 피드 상세 페이지로 접속하면 이미지가 화면에 꽉 차게 보여졌습니다.
- 따라서 데스크탑에서 서비스를 이용하는 사용자가가 본문의 내용을 한 눈에 파악하기 어렵다는 단점이 있었습니다.
- 화면의 최대 크기를 설정하면 데스크탑에서 내용 파악이 쉽도록 하여 사용자 경험의 향상을 기대할 수 있습니다.

## 자료 (스크린샷 등)

![Feb-08-2023 11-26-02](https://user-images.githubusercontent.com/88873956/217413417-b81f0bb9-184f-47f9-bdcc-c9e3df6f1266.gif)
